### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/gotcha/Cargo.toml
+++ b/gotcha/Cargo.toml
@@ -4,6 +4,7 @@ description = "enhanced web framework based on actix-web"
 edition = "2021"
 version = "0.1.9"
 license = "MIT"
+repository = "https://github.com/Kilerd/gotcha/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow crates.io, rust-digger and others to link to it.