### PR TITLE
feat: implement #[api(skip)] for OpenAPI parameter exclusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "gotcha_macro",
     "examples/*"
 ]
+exclude = ["examples/clouldflare-worker"]
 default-members = ["gotcha", "gotcha_macro"]
 
 [workspace.dependencies]

--- a/examples/openapi/src/main.rs
+++ b/examples/openapi/src/main.rs
@@ -1,6 +1,8 @@
 use gotcha::{api, ConfigWrapper, GotchaApp, GotchaContext, GotchaRouter, Json, Path, Schematic};
 use serde::{Deserialize, Serialize};
 
+mod test_skip;
+
 #[derive(Schematic, Serialize, Deserialize, Debug)]
 pub struct ResponseWrapper<T: Schematic> {
     pub code: i32,
@@ -100,6 +102,10 @@ impl GotchaApp for App {
             .get("/pets/:pet_id", get_pet)
             .put("/pets/:pet_id", update_pet_info)
             .put("/pets/:pet_id/address/:address_id", update_pet_address_detail)
+            // Test skip functionality
+            .post("/test/skip-json/:key_id", test_skip::test_skip_json)
+            .post("/test/skip-query/:key_id", test_skip::test_skip_query)
+            .post("/test/no-skip/:key_id", test_skip::test_no_skip)
     }
 
     async fn state<'a, 'b>(&'a self, _config: &'b ConfigWrapper<Self::Config>) -> Result<Self::State, Box<dyn std::error::Error>> {

--- a/examples/openapi/src/test_skip.rs
+++ b/examples/openapi/src/test_skip.rs
@@ -1,0 +1,63 @@
+use gotcha::{api, Json, Path, Query, Schematic};
+use serde::{Deserialize, Serialize};
+
+#[derive(Schematic, Serialize, Deserialize)]
+pub struct ApiKey {
+    pub id: u32,
+    pub name: String,
+}
+
+#[derive(Schematic, Serialize, Deserialize)]
+pub struct FilterParams {
+    pub active: Option<bool>,
+    pub limit: Option<u32>,
+}
+
+#[derive(Schematic, Serialize, Deserialize)]
+pub struct CreateApiKeyRequest {
+    pub name: String,
+    pub description: String,
+}
+
+/// Test endpoint with skipped Json body parameter - only Path parameter should appear in OpenAPI
+#[api(id = "test_skip_json", group = "test_skip")]
+pub async fn test_skip_json(
+    Path(key_id): Path<u32>,
+    #[api(skip)] Json(body): Json<CreateApiKeyRequest>,  // This will be skipped in OpenAPI
+) -> Json<ApiKey> {
+    // The Json(body) parameter should be skipped in OpenAPI docs
+    // Only Path(key_id) should appear in the generated OpenAPI
+    Json(ApiKey {
+        id: key_id,
+        name: body.name,
+    })
+}
+
+/// Test endpoint with skipped Query parameter - only Path and Json should appear in OpenAPI
+#[api(id = "test_skip_query", group = "test_skip")]
+pub async fn test_skip_query(
+    Path(key_id): Path<u32>,
+    #[api(skip)] Query(filter): Query<FilterParams>,  // This will be skipped in OpenAPI
+    Json(body): Json<CreateApiKeyRequest>,
+) -> Json<ApiKey> {
+    // The Query(filter) parameter should be skipped in OpenAPI docs
+    // Path(key_id) and Json(body) should appear in the generated OpenAPI
+    Json(ApiKey {
+        id: key_id,
+        name: format!("{} (limit: {:?})", body.name, filter.limit),
+    })
+}
+
+/// Test endpoint without skip - all parameters visible in OpenAPI
+#[api(id = "test_no_skip", group = "test_skip")]
+pub async fn test_no_skip(
+    Path(key_id): Path<u32>,
+    Query(filter): Query<FilterParams>,
+    Json(body): Json<CreateApiKeyRequest>,
+) -> Json<ApiKey> {
+    // All parameters should appear in OpenAPI docs
+    Json(ApiKey {
+        id: key_id,
+        name: format!("{} (limit: {:?})", body.name, filter.limit),
+    })
+}

--- a/gotcha/src/openapi/schematic.rs
+++ b/gotcha/src/openapi/schematic.rs
@@ -52,7 +52,7 @@ pub trait Schematic {
 
 /// ParameterProvider is a trait that defines the value which can be used as a parameter.
 pub trait ParameterProvider {
-    fn generate(url: String) -> Either<Vec<Parameter>, RequestBody> {
+    fn generate(_url: String) -> Either<Vec<Parameter>, RequestBody> {
         Either::Left(vec![])
     }
 }

--- a/gotcha/src/router.rs
+++ b/gotcha/src/router.rs
@@ -81,6 +81,7 @@ impl<State: Clone + Send + Sync + 'static> GotchaRouter<State> {
     /// let router: GotchaRouter<()> = GotchaRouter::default()
     ///     .method_route("/", MethodFilter::GET, hello_world);
     /// ```
+    #[allow(unused_mut)]
     pub fn method_route<H, T>(mut self, path: &str, method: MethodFilter, handler: H) -> Self
     where
         H: Handler<T, State>,

--- a/gotcha_macro/src/schematic/named_struct.rs
+++ b/gotcha_macro/src/schematic/named_struct.rs
@@ -1,6 +1,5 @@
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
-use syn::GenericParam;
 
 use crate::schematic::ParameterStructFieldOpt;
 use crate::utils::AttributesExt;


### PR DESCRIPTION
## Summary

Implement the `#[api(skip)]` attribute to exclude specific handler parameters from OpenAPI documentation. This allows developers to hide internal parameters like `Extension` and `State` from the generated OpenAPI spec.

## Changes

- Add skip attribute detection logic in gotcha_macro route handler
- Preserve non-api attributes when processing function parameters  
- Fix workspace compilation by excluding cloudflare-worker example
- Add comprehensive test cases demonstrating skip functionality
- Clean up compiler warnings

## Test Plan

- Run `cargo test --workspace` to verify all tests pass
- Visit `/redoc` or `/openapi.json` on the example to verify skip functionality works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)