### PR TITLE
Add Schematic support for rust_decimal::Decimal

### DIFF
--- a/gotcha/Cargo.toml
+++ b/gotcha/Cargo.toml
@@ -50,6 +50,7 @@ worker = {version = "0.5.0", features = ["http"], optional = true}
 thiserror = "1.0"
 serde_json = "1"    
 bigdecimal = "0.4"
+rust_decimal = "1.36"
 uuid = {version =  "1.10" }
 regex = "1.7"
 

--- a/gotcha/src/openapi/schematic.rs
+++ b/gotcha/src/openapi/schematic.rs
@@ -279,6 +279,24 @@ impl Schematic for BigDecimal {
     }
 }
 
+impl Schematic for rust_decimal::Decimal {
+    fn name() -> &'static str {
+        "decimal"
+    }
+
+    fn required() -> bool {
+        true
+    }
+
+    fn type_() -> &'static str {
+        "string"
+    }
+
+    fn format() -> Option<String> {
+        Some("decimal".to_string())
+    }
+}
+
 impl<T: Schematic> Schematic for HashSet<T> {
     fn name() -> &'static str {
         T::name()

--- a/gotcha/tests/pass/openapi/rust_decimal.json
+++ b/gotcha/tests/pass/openapi/rust_decimal.json
@@ -1,0 +1,21 @@
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "price": {
+        "type": "string",
+        "format": "decimal"
+      },
+      "discount": {
+        "type": "string",
+        "format": "decimal",
+        "nullable": true
+      }
+    },
+    "required": ["name", "price"]
+  },
+  "required": true
+}

--- a/gotcha/tests/pass/openapi/rust_decimal.rs
+++ b/gotcha/tests/pass/openapi/rust_decimal.rs
@@ -1,0 +1,23 @@
+use gotcha::openapi::schematic::Schematic;
+use gotcha_macro::Schematic;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Schematic)]
+struct Product {
+    name: String,
+    price: Decimal,
+    discount: Option<Decimal>,
+}
+
+#[test]
+fn test_decimal_schema_generation() {
+    let schema = Product::generate_schema();
+    let json = serde_json::to_string_pretty(&schema).unwrap();
+
+    let expected = include_str!("rust_decimal.json");
+    assert_json_diff::assert_json_eq!(
+        serde_json::from_str::<serde_json::Value>(&json).unwrap(),
+        serde_json::from_str::<serde_json::Value>(expected).unwrap()
+    );
+}


### PR DESCRIPTION
## Summary

Add support for `rust_decimal::Decimal` type in the Schematic trait, enabling OpenAPI schema generation for structs using this decimal type. Maps Decimal to string type with "decimal" format, consistent with existing BigDecimal support.

## Changes

- Add `rust_decimal` dependency to Cargo.toml
- Implement Schematic trait for `rust_decimal::Decimal`
- Add test case validating schema generation for decimal fields

## Test Plan

- [x] Test compiles without errors
- [x] Test validates Decimal fields in struct schemas
- [x] Test covers both required and optional decimal fields