### PR TITLE
feat!: coherent error model + unified app APIs (Tier 1)

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -23,7 +23,7 @@ impl GotchaApp for App {
     }
 
     #[allow(clippy::manual_async_fn)]
-    fn state(&self, _config: &ConfigWrapper<Self::Config>) -> impl std::future::Future<Output = Result<Self::State, Box<dyn std::error::Error>>> + Send {
+    fn state(&self, _config: &ConfigWrapper<Self::Config>) -> impl std::future::Future<Output = Result<Self::State, gotcha::GotchaError>> + Send {
         async move { Ok(()) }
     }
 }

--- a/examples/extension/src/main.rs
+++ b/examples/extension/src/main.rs
@@ -79,7 +79,7 @@ impl GotchaApp for App {
     }
 
     #[allow(clippy::manual_async_fn)]
-    fn state(&self, _config: &ConfigWrapper<Self::Config>) -> impl std::future::Future<Output = Result<Self::State, Box<dyn std::error::Error>>> + Send {
+    fn state(&self, _config: &ConfigWrapper<Self::Config>) -> impl std::future::Future<Output = Result<Self::State, gotcha::GotchaError>> + Send {
         async { Ok(()) }
     }
 }

--- a/examples/openapi/src/main.rs
+++ b/examples/openapi/src/main.rs
@@ -108,7 +108,7 @@ impl GotchaApp for App {
             .post("/test/no-skip/:key_id", test_skip::test_no_skip)
     }
 
-    async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> Result<Self::State, Box<dyn std::error::Error>> {
+    async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> Result<Self::State, gotcha::GotchaError> {
         Ok(())
     }
 }

--- a/examples/task/src/main.rs
+++ b/examples/task/src/main.rs
@@ -19,11 +19,11 @@ impl GotchaApp for App {
         router.get("/", hello_world)
     }
 
-    async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> Result<Self::State, Box<dyn std::error::Error>> {
+    async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> Result<Self::State, gotcha::GotchaError> {
         Ok(())
     }
 
-    async fn tasks(&self, task_scheduler: &mut TaskScheduler<Self::State, Self::Config>) -> Result<(), Box<dyn std::error::Error>> {
+    async fn tasks(&self, task_scheduler: &mut TaskScheduler<Self::State, Self::Config>) -> Result<(), gotcha::GotchaError> {
         task_scheduler.interval("interval task", std::time::Duration::from_secs(1), interval_task);
         Ok(())
     }

--- a/examples/testing-guide/src/lib.rs
+++ b/examples/testing-guide/src/lib.rs
@@ -229,7 +229,7 @@ impl GotchaApp for App {
     type State = AppState;
     type Config = AppConfig;
 
-    async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> Result<Self::State, Box<dyn std::error::Error>> {
+    async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> Result<Self::State, gotcha::GotchaError> {
         Ok(AppState::default())
     }
 

--- a/gotcha/src/builder.rs
+++ b/gotcha/src/builder.rs
@@ -26,14 +26,19 @@ use std::str::FromStr;
 use axum::extract::Request;
 use axum::handler::Handler;
 use axum::routing::MethodRouter;
-use axum::Router;
 use serde::{Deserialize, Serialize};
 use tower_layer::Layer;
 use tower_service::Service;
 
 use crate::config::{BasicConfig, Config, ConfigBuilder, ConfigState, ConfigWrapper, GotchaConfigLoader};
+use crate::error::{GotchaError, GotchaResult};
 use crate::router::{GotchaRouter, Responder};
 use crate::GotchaContext;
+
+/// A one-shot closure that registers background tasks on the scheduler when the
+/// server starts.
+#[cfg(feature = "task")]
+type TaskRegistrar<S, C> = Box<dyn FnOnce(&mut crate::TaskScheduler<S, C>) + Send>;
 
 /// Default empty configuration for simple applications
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -55,6 +60,8 @@ where
     state: Option<S>,
     config: Option<ConfigWrapper<C>>,
     config_builder: Option<ConfigState>,
+    #[cfg(feature = "task")]
+    tasks: Vec<TaskRegistrar<S, C>>,
 }
 
 impl Default for Gotcha<EmptyState, EmptyConfig> {
@@ -81,6 +88,8 @@ impl Gotcha<EmptyState, EmptyConfig> {
             state: None,
             config: None,
             config_builder: None,
+            #[cfg(feature = "task")]
+            tasks: Vec::new(),
         }
     }
 }
@@ -123,6 +132,8 @@ impl Gotcha {
             state: None,
             config: None,
             config_builder: None,
+            #[cfg(feature = "task")]
+            tasks: Vec::new(),
         }
     }
 
@@ -154,6 +165,8 @@ impl Gotcha {
             state: None,
             config: None,
             config_builder: None,
+            #[cfg(feature = "task")]
+            tasks: Vec::new(),
         }
     }
 
@@ -187,6 +200,8 @@ impl Gotcha {
             state: None,
             config: None,
             config_builder: None,
+            #[cfg(feature = "task")]
+            tasks: Vec::new(),
         }
     }
 }
@@ -224,7 +239,7 @@ where
     ///             .env("APP")
     ///     })?;
     /// ```
-    pub fn build_config<F>(mut self, builder_fn: F) -> Result<Self, crate::config::ConfigError>
+    pub fn build_config<F>(mut self, builder_fn: F) -> GotchaResult<Self>
     where
         F: FnOnce(ConfigBuilder) -> ConfigBuilder,
     {
@@ -477,6 +492,36 @@ where
         self
     }
 
+    /// Add a HEAD route
+    pub fn head<H, T>(mut self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, GotchaContext<S, C>>,
+        T: 'static,
+    {
+        self.router = self.router.head(path, handler);
+        self
+    }
+
+    /// Add an OPTIONS route
+    pub fn options<H, T>(mut self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, GotchaContext<S, C>>,
+        T: 'static,
+    {
+        self.router = self.router.options(path, handler);
+        self
+    }
+
+    /// Add a TRACE route
+    pub fn trace<H, T>(mut self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, GotchaContext<S, C>>,
+        T: 'static,
+    {
+        self.router = self.router.trace(path, handler);
+        self
+    }
+
     /// Add a route with custom method
     pub fn route(mut self, path: &str, method_router: MethodRouter<GotchaContext<S, C>>) -> Self {
         self.router = self.router.route(path, method_router);
@@ -530,6 +575,42 @@ where
         self
     }
 
+    /// Set a fallback handler for requests that don't match any route
+    pub fn fallback<H, T>(mut self, handler: H) -> Self
+    where
+        H: Handler<T, GotchaContext<S, C>>,
+        T: 'static,
+    {
+        self.router = self.router.fallback(handler);
+        self
+    }
+
+    /// Register background tasks (requires the `task` feature).
+    ///
+    /// The closure receives a [`TaskScheduler`](crate::TaskScheduler) when the
+    /// server starts, on which you can register `cron` / `interval` jobs. This
+    /// brings the builder to parity with `GotchaApp::tasks`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use gotcha::prelude::*;
+    /// use std::time::Duration;
+    ///
+    /// let app = Gotcha::new().tasks(|scheduler| {
+    ///     scheduler.interval("heartbeat", Duration::from_secs(60), |_ctx| async move {
+    ///         tracing::info!("tick");
+    ///     });
+    /// });
+    /// ```
+    #[cfg(feature = "task")]
+    pub fn tasks<F>(mut self, register: F) -> Self
+    where
+        F: FnOnce(&mut crate::TaskScheduler<S, C>) + Send + 'static,
+    {
+        self.tasks.push(Box::new(register));
+        self
+    }
+
     /// Add CORS support (requires "cors" feature)
     #[cfg(feature = "cors")]
     pub fn with_cors(self) -> Self {
@@ -559,45 +640,60 @@ where
     ///     Ok(())
     /// }
     /// ```
-    pub async fn listen<A>(self, addr: A) -> Result<(), Box<dyn std::error::Error>>
+    pub async fn listen<A>(self, addr: A) -> GotchaResult<()>
     where
         A: AsRef<str>,
     {
         let addr_str = addr.as_ref();
-        let socket_addr: SocketAddr = addr_str.parse().map_err(|_| format!("Invalid address format: {}", addr_str))?;
-
+        let socket_addr: SocketAddr = addr_str.parse().map_err(|_| GotchaError::InvalidAddress(addr_str.to_string()))?;
         self.listen_on(socket_addr).await
     }
 
     /// Start the server on a specific socket address
-    pub async fn listen_on(self, addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn listen_on(self, addr: SocketAddr) -> GotchaResult<()> {
         tracing::info!("🚀 Starting Gotcha server on {}", addr);
 
         let context = self.build_context().await?;
-        let app_router = self.build_app_router(context).await?;
 
-        let listener = tokio::net::TcpListener::bind(addr).await?;
+        #[cfg(feature = "task")]
+        {
+            let tasks = self.tasks;
+            if !tasks.is_empty() {
+                let mut scheduler = crate::TaskScheduler::new(context.clone());
+                for register in tasks {
+                    register(&mut scheduler);
+                }
+            }
+        }
+
+        let app_router = self.router.into_axum_router(context);
+
+        let listener = tokio::net::TcpListener::bind(addr).await.map_err(|source| GotchaError::Bind {
+            addr: addr.to_string(),
+            source,
+        })?;
         tracing::info!("✅ Server listening on http://{}", addr);
 
-        axum::serve(listener, app_router).await?;
+        axum::serve(listener, app_router).await.map_err(GotchaError::Io)?;
         Ok(())
     }
 
     /// Start the server using the configured host and port
-    pub async fn run(self) -> Result<(), Box<dyn std::error::Error>> {
-        let host = self.host.clone();
-        let port = self.port;
-        let addr = SocketAddrV4::new(Ipv4Addr::from_str(&host)?, port);
+    pub async fn run(self) -> GotchaResult<()> {
+        let ip = Ipv4Addr::from_str(&self.host).map_err(|_| GotchaError::InvalidAddress(self.host.clone()))?;
+        let addr = SocketAddrV4::new(ip, self.port);
         self.listen_on(SocketAddr::V4(addr)).await
     }
 
-    /// Build the application context
-    async fn build_context(&self) -> Result<GotchaContext<S, C>, Box<dyn std::error::Error>> {
-        // Load or create configuration
+    /// Build the application context (loads configuration and resolves state).
+    ///
+    /// On configuration failure this logs a warning and falls back to defaults,
+    /// keeping the builder lenient. Use the trait API for strict config loading.
+    async fn build_context(&self) -> GotchaResult<GotchaContext<S, C>> {
         let config = match (&self.config, &self.config_builder) {
-            // If explicit config is set, use it
+            // Explicit config wins
             (Some(config), _) => config.clone(),
-            // If we have accumulated configuration sources, build them
+            // Accumulated configuration sources
             (None, Some(state)) => {
                 let builder = ConfigBuilder::from_state(state.clone());
                 match builder.build::<ConfigWrapper<C>>() {
@@ -606,8 +702,7 @@ where
                         config
                     }
                     Err(e) => {
-                        tracing::warn!("Failed to load accumulated configuration: {}, using defaults", e);
-                        tracing::info!("💡 Check configuration files and environment variables");
+                        tracing::warn!("Failed to load accumulated configuration: {e}, using defaults");
                         ConfigWrapper {
                             basic: BasicConfig {
                                 host: self.host.clone(),
@@ -618,61 +713,28 @@ where
                     }
                 }
             }
-            // No explicit config or builder, try legacy loading then fall back to defaults
-            (None, None) => {
-                match std::panic::catch_unwind(|| GotchaConfigLoader::load::<ConfigWrapper<C>>(std::env::var("GOTCHA_ACTIVE_PROFILE").ok())) {
-                    Ok(config) => config,
-                    Err(_) => {
-                        // If loading fails, use default
-                        tracing::warn!("Failed to load configuration, using defaults");
-                        ConfigWrapper {
-                            basic: BasicConfig {
-                                host: self.host.clone(),
-                                port: self.port,
-                            },
-                            application: C::default(),
-                        }
+            // Default loading, falling back to defaults on failure
+            (None, None) => match GotchaConfigLoader::load::<ConfigWrapper<C>>(std::env::var("GOTCHA_ACTIVE_PROFILE").ok()) {
+                Ok(config) => config,
+                Err(e) => {
+                    tracing::warn!("Failed to load configuration: {e}, using defaults");
+                    ConfigWrapper {
+                        basic: BasicConfig {
+                            host: self.host.clone(),
+                            port: self.port,
+                        },
+                        application: C::default(),
                     }
                 }
-            }
+            },
         };
 
-        // Create or use provided state
         let state = match &self.state {
             Some(state) => state.clone(),
             None => S::default(),
         };
 
         Ok(GotchaContext { config, state })
-    }
-
-    /// Build the final Axum router
-    async fn build_app_router(self, context: GotchaContext<S, C>) -> Result<Router, Box<dyn std::error::Error>> {
-        let GotchaRouter {
-            #[cfg(feature = "openapi")]
-            operations,
-            router: raw_router,
-        } = self.router;
-
-        #[cfg(feature = "openapi")]
-        let openapi_spec = crate::openapi::generate_openapi(operations);
-
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "openapi")] {
-                use axum::Json;
-                let router = raw_router
-                    .with_state(context.clone())
-                    .route("/openapi.json", axum::routing::get(move || async move {
-                        Json(openapi_spec.clone())
-                    }))
-                    .route("/redoc", axum::routing::get(crate::openapi::openapi_html))
-                    .route("/scalar", axum::routing::get(crate::openapi::scalar_html));
-            } else {
-                let router = raw_router.with_state(context.clone());
-            }
-        }
-
-        Ok(router)
     }
 }
 
@@ -692,7 +754,7 @@ impl Gotcha<EmptyState, EmptyConfig> {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn quick_start() -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn quick_start() -> GotchaResult<Self> {
         tracing_subscriber::fmt::init();
         Ok(Self::new())
     }

--- a/gotcha/src/config.rs
+++ b/gotcha/src/config.rs
@@ -164,13 +164,16 @@ impl Config {
 pub struct GotchaConfigLoader;
 
 impl GotchaConfigLoader {
-    pub fn load<T: for<'de> Deserialize<'de>>(_profile: Option<String>) -> T {
+    /// Load configuration from `configurations/application.toml` + the `APP`
+    /// environment prefix. Returns an error instead of panicking on failure.
+    ///
+    /// NOTE: `_profile` is not yet honored here — see the config-hardening issue.
+    pub fn load<T: for<'de> Deserialize<'de>>(_profile: Option<String>) -> ConfigResult<T> {
         Config::builder()
             .file_optional("configurations/application.toml")
             .env("APP")
             .enable_vars()
             .build()
-            .expect("Failed to load configuration")
     }
 }
 

--- a/gotcha/src/error.rs
+++ b/gotcha/src/error.rs
@@ -1,7 +1,71 @@
+//! The unified error type for the Gotcha framework.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+use crate::config::ConfigError;
+
+/// The error type returned by framework operations (`run`, `listen`, config
+/// loading, …). It implements [`IntoResponse`], so it can also be returned
+/// directly from handlers, where it renders as a `500 Internal Server Error`.
+#[derive(Debug, Error)]
 pub enum GotchaError {
-    #[error("Config error: {0}")]
-    ConfigError(String),
+    /// Configuration could not be loaded or parsed.
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+
+    /// The configured listen address was not a valid socket address.
+    #[error("invalid listen address: {0}")]
+    InvalidAddress(String),
+
+    /// The server failed to bind to the given address.
+    #[error("failed to bind server to {addr}: {source}")]
+    Bind { addr: String, source: std::io::Error },
+
+    /// An I/O error from the runtime (e.g. `axum::serve`).
+    #[error(transparent)]
+    Io(std::io::Error),
+
+    /// A generic, framework-level error message.
+    #[error("{0}")]
+    Message(String),
+
+    /// Any other error — typically produced by a user-provided hook.
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl GotchaError {
+    /// Build a [`GotchaError::Message`] from anything `Display`.
+    pub fn message(msg: impl std::fmt::Display) -> Self {
+        Self::Message(msg.to_string())
+    }
+}
+
+/// Convenient result alias for framework operations.
+pub type GotchaResult<T> = Result<T, GotchaError>;
+
+impl IntoResponse for GotchaError {
+    fn into_response(self) -> Response {
+        tracing::error!(error = %self, "request failed with a gotcha error");
+        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_as_internal_server_error() {
+        let response = GotchaError::message("boom").into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn config_error_converts() {
+        let err: GotchaError = ConfigError::Error("bad".into()).into();
+        assert!(matches!(err, GotchaError::Config(_)));
+    }
 }

--- a/gotcha/src/lib.rs
+++ b/gotcha/src/lib.rs
@@ -36,7 +36,7 @@
 //! ## Advanced Example (Traditional Trait API)
 //!
 //! ```no_run
-//! use gotcha::{async_trait, ConfigWrapper, GotchaApp, GotchaContext, GotchaRouter, Responder, State};
+//! use gotcha::{ConfigWrapper, GotchaApp, GotchaContext, GotchaResult, GotchaRouter, Responder, State};
 //! use serde::{Deserialize, Serialize};
 //!
 //! pub async fn hello_world(_state: State<ConfigWrapper<Config>>) -> impl Responder {
@@ -50,7 +50,6 @@
 //!
 //! pub struct App {}
 //!
-//! #[async_trait]
 //! impl GotchaApp for App {
 //!     type State = ();
 //!     type Config = Config;
@@ -59,7 +58,7 @@
 //!         router.get("/", hello_world)
 //!     }
 //!
-//!     async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> Result<Self::State, Box<dyn std::error::Error>> {
+//!     async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> GotchaResult<Self::State> {
 //!         Ok(())
 //!     }
 //! }
@@ -98,6 +97,7 @@ pub use {axum, inventory, tracing};
 
 pub use crate::builder::{EmptyConfig, EmptyState, Gotcha};
 pub use crate::config::GotchaConfigLoader;
+pub use crate::error::{GotchaError, GotchaResult};
 
 #[cfg(feature = "message")]
 pub mod message;
@@ -167,14 +167,14 @@ pub trait GotchaApp: Sized + Send + Sync {
     type State: Clone + Send + Sync + 'static;
     type Config: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de> + Default;
 
-    fn config(&self) -> impl std::future::Future<Output = Result<ConfigWrapper<Self::Config>, Box<dyn std::error::Error>>> + Send {
+    fn config(&self) -> impl std::future::Future<Output = GotchaResult<ConfigWrapper<Self::Config>>> + Send {
         async move {
-            let config = GotchaConfigLoader::load::<ConfigWrapper<Self::Config>>(std::env::var("GOTCHA_ACTIVE_PROFILE").ok());
+            let config = GotchaConfigLoader::load::<ConfigWrapper<Self::Config>>(std::env::var("GOTCHA_ACTIVE_PROFILE").ok())?;
             Ok(config)
         }
     }
 
-    fn logger(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn logger(&self) -> GotchaResult<()> {
         tracing_subscriber::registry()
             .with(fmt::layer())
             .with(
@@ -190,48 +190,22 @@ pub trait GotchaApp: Sized + Send + Sync {
 
     fn routes(&self, router: GotchaRouter<GotchaContext<Self::State, Self::Config>>) -> GotchaRouter<GotchaContext<Self::State, Self::Config>>;
 
-    fn state(&self, config: &ConfigWrapper<Self::Config>) -> impl std::future::Future<Output = Result<Self::State, Box<dyn std::error::Error>>> + Send;
+    fn state(&self, config: &ConfigWrapper<Self::Config>) -> impl std::future::Future<Output = GotchaResult<Self::State>> + Send;
 
     #[cfg(feature = "task")]
-    fn tasks(
-        &self, _task_scheduler: &mut TaskScheduler<Self::State, Self::Config>,
-    ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error>>> + Send {
+    fn tasks(&self, _task_scheduler: &mut TaskScheduler<Self::State, Self::Config>) -> impl std::future::Future<Output = GotchaResult<()>> + Send {
         async { Ok(()) }
     }
 
-    fn build_router(
-        &self, context: GotchaContext<Self::State, Self::Config>,
-    ) -> impl std::future::Future<Output = Result<axum::Router, Box<dyn std::error::Error>>> + Send {
+    fn build_router(&self, context: GotchaContext<Self::State, Self::Config>) -> impl std::future::Future<Output = GotchaResult<axum::Router>> + Send {
         async move {
             let router = GotchaRouter::<GotchaContext<Self::State, Self::Config>>::default();
             let router = self.routes(router);
-
-            let GotchaRouter {
-                #[cfg(feature = "openapi")]
-                operations,
-                router: raw_router,
-            } = router;
-
-            #[cfg(feature = "openapi")]
-            let openapi_spec = crate::openapi::generate_openapi(operations);
-
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "openapi")] {
-                    let router = raw_router
-                    .with_state(context.clone())
-                    .route("/openapi.json", axum::routing::get(|| async move { Json(openapi_spec.clone()) }))
-                    .route("/redoc", axum::routing::get(openapi::openapi_html))
-                    .route("/scalar", axum::routing::get(openapi::scalar_html));
-                }else {
-                    let router = raw_router
-                    .with_state(context.clone());
-                }
-            }
-            Ok(router)
+            Ok(router.into_axum_router(context))
         }
     }
 
-    fn run(self) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error>>> + Send {
+    fn run(self) -> impl std::future::Future<Output = GotchaResult<()>> + Send {
         async move {
             use std::net::{Ipv4Addr, SocketAddrV4};
             use std::str::FromStr;
@@ -251,9 +225,13 @@ pub trait GotchaApp: Sized + Send + Sync {
                 }
             }
 
-            let addr = SocketAddrV4::new(Ipv4Addr::from_str(&config.basic.host)?, config.basic.port);
-            let listener = tokio::net::TcpListener::bind(addr).await?;
-            axum::serve(listener, router).await?;
+            let ip = Ipv4Addr::from_str(&config.basic.host).map_err(|_| GotchaError::InvalidAddress(config.basic.host.clone()))?;
+            let addr = SocketAddrV4::new(ip, config.basic.port);
+            let listener = tokio::net::TcpListener::bind(addr).await.map_err(|source| GotchaError::Bind {
+                addr: addr.to_string(),
+                source,
+            })?;
+            axum::serve(listener, router).await.map_err(GotchaError::Io)?;
             Ok(())
         }
     }

--- a/gotcha/src/prelude.rs
+++ b/gotcha/src/prelude.rs
@@ -26,6 +26,7 @@ pub use crate::builder::{EmptyConfig, EmptyState, Gotcha};
 
 // Essential traits and types
 pub use crate::config::{ConfigWrapper, GotchaConfigLoader};
+pub use crate::error::{GotchaError, GotchaResult};
 pub use crate::router::Responder;
 pub use crate::{GotchaApp, GotchaContext, GotchaRouter};
 

--- a/gotcha/src/router.rs
+++ b/gotcha/src/router.rs
@@ -204,6 +204,28 @@ impl<State: Clone + Send + Sync + 'static> GotchaRouter<State> {
             router: self.router.fallback(handler),
         }
     }
+
+    /// Finalize this router into a plain `axum::Router`, injecting `state`.
+    ///
+    /// When the `openapi` feature is enabled, this also mounts the generated
+    /// spec at `/openapi.json` and the Redoc / Scalar UIs at `/redoc` and
+    /// `/scalar`. This is the single assembly path shared by both the
+    /// [`GotchaApp`](crate::GotchaApp) trait and the [`Gotcha`](crate::Gotcha)
+    /// builder.
+    pub(crate) fn into_axum_router(self, state: State) -> Router {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "openapi")] {
+                let openapi_spec = crate::openapi::generate_openapi(self.operations);
+                self.router
+                    .with_state(state)
+                    .route("/openapi.json", axum::routing::get(move || async move { axum::Json(openapi_spec.clone()) }))
+                    .route("/redoc", axum::routing::get(crate::openapi::openapi_html))
+                    .route("/scalar", axum::routing::get(crate::openapi::scalar_html))
+            } else {
+                self.router.with_state(state)
+            }
+        }
+    }
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Addresses the Tier 1 roadmap items: **#31** (coherent error model) and **#30** (unify the trait & builder APIs). Breaking change, bound for the next (0.4) release.

## #31 — coherent error model
- New **`GotchaError`** (thiserror) implementing **`IntoResponse`** (renders a `500`), plus a **`GotchaResult<T>`** alias; both re-exported from the crate root and the prelude. `GotchaError` can now be returned directly from handlers.
- **De-panicked config loading**: `GotchaConfigLoader::load` returns `ConfigResult` instead of `.expect(...)`, and the builder's `std::panic::catch_unwind` workaround is removed. (Closes the panic item of #27; the `GOTCHA_ACTIVE_PROFILE` / required-file items of #27 remain.)
- Threaded `GotchaResult` through `GotchaApp` (config/logger/state/tasks/build_router/run) and the `Gotcha` builder (listen/listen_on/run/build_config/build_context/quick_start) in place of `Box<dyn Error>`.

## #30 — unify trait & builder APIs
- Extracted the duplicated router-assembly (`lib.rs` `build_router` vs `builder.rs` `build_app_router`) into a single shared **`GotchaRouter::into_axum_router`**.
- Builder reaches routing parity with `GotchaRouter`: adds **`head`/`options`/`trace`/`fallback`**.
- Builder gains **`tasks(...)`** — it can now schedule background jobs, matching `GotchaApp::tasks` (previously the builder couldn't schedule tasks at all).

## Migration (→ 0.4)
- `GotchaApp::state`/`tasks` and the framework surfaces now return `GotchaResult` (i.e. `Result<_, GotchaError>`) instead of `Box<dyn Error>`. Existing `impl GotchaApp` blocks change their `state()`/`tasks()` return type; a body that returns `Ok(...)` is otherwise unchanged.
- User `main()` functions returning `Box<dyn Error>` and calling `app.run().await?` are **unaffected** (`GotchaError: std::error::Error`).
- In-repo examples updated accordingly.

## Deferred (noted on #30)
Not in this PR: removing the builder's `S: Default` requirement, config-derived **async** state in the builder, and fully collapsing the two entry points into one canonical API. Both the trait and the builder remain public and now share machinery.

## Verification (local)
`cargo build --workspace`, `cargo test -p gotcha --features "openapi task cors static_files message prometheus"` (incl. trybuild pass suite), the testing-guide `TestServer` integration suite, two new `error.rs` unit tests, `cargo clippy --all-features --workspace -- -D warnings`, and `cargo fmt --all -- --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)