### PR TITLE
fix(schematic): DateTime<Utc> format, Vec requiredness, primitive names (#37)

### DIFF
--- a/gotcha_core/src/lib.rs
+++ b/gotcha_core/src/lib.rs
@@ -100,7 +100,7 @@ macro_rules! impl_primitive_type {
     };
 }
 
-impl_primitive_type! { i8, "i32", "integer"}
+impl_primitive_type! { i8, "i8", "integer"}
 impl_primitive_type! { i16, "i16", "integer"}
 impl_primitive_type! { i32, "i32", "integer"}
 impl_primitive_type! { i64, "i64", "integer"}
@@ -111,9 +111,9 @@ impl_primitive_type! { u32, "u32", "integer"}
 impl_primitive_type! { u64, "u64", "integer"}
 impl_primitive_type! { usize, "usize", "integer"}
 impl_primitive_type! { String, "string", "string"}
-impl_primitive_type! { bool, "string", "boolean"}
-impl_primitive_type! { f32, "string", "number"}
-impl_primitive_type! { f64, "string", "number"}
+impl_primitive_type! { bool, "bool", "boolean"}
+impl_primitive_type! { f32, "f32", "number"}
+impl_primitive_type! { f64, "f64", "number"}
 
 impl Schematic for () {
     fn name() -> &'static str {
@@ -269,7 +269,10 @@ impl<T: Schematic> Schematic for Vec<T> {
     }
 
     fn required() -> bool {
-        T::required()
+        // A `Vec<T>` field is always present (possibly as an empty array) unless
+        // it is wrapped in `Option`; its requiredness must not depend on whether
+        // the element type is required. Consistent with `HashSet`/`HashMap`.
+        true
     }
 
     fn type_() -> &'static str {
@@ -387,7 +390,7 @@ impl<K: ToString, V: Schematic> Schematic for HashMap<K, V> {
 
 impl Schematic for DateTime<Utc> {
     fn name() -> &'static str {
-        "string"
+        "datetime"
     }
 
     fn required() -> bool {
@@ -396,5 +399,37 @@ impl Schematic for DateTime<Utc> {
 
     fn type_() -> &'static str {
         "string"
+    }
+
+    fn format() -> Option<String> {
+        Some("date-time".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn datetime_utc_has_date_time_format() {
+        let schema = <DateTime<Utc> as Schematic>::generate_schema();
+        assert_eq!(schema.schema._type.as_deref(), Some("string"));
+        assert_eq!(schema.schema.format.as_deref(), Some("date-time"));
+    }
+
+    #[test]
+    fn vec_field_is_required_regardless_of_element() {
+        // A bare Vec field is present (possibly empty), so it is required even
+        // when the element type is not (previously delegated to `T::required`).
+        assert!(<Vec<Option<u8>> as Schematic>::required());
+        assert!(<Vec<u8> as Schematic>::required());
+    }
+
+    #[test]
+    fn primitive_names_are_accurate() {
+        assert_eq!(<i8 as Schematic>::name(), "i8");
+        assert_eq!(<bool as Schematic>::name(), "bool");
+        assert_eq!(<f32 as Schematic>::name(), "f32");
+        assert_eq!(<f64 as Schematic>::name(), "f64");
     }
 }


### PR DESCRIPTION
Knocks out several clearly-correct items from #37 (Schematic output correctness). Scoped to `gotcha_core` data-type impls — no macro-codegen changes.

## Fixes
- **`DateTime<Utc>` dropped its `date-time` format** → now emits `format: "date-time"`, matching `NaiveDateTime`. Real output defect for any `DateTime<Utc>` field.
- **`Vec<T>::required()` delegated to `T::required()`** → now always `true`. A bare `Vec` field is present (possibly empty) regardless of element optionality, so `Vec<Option<X>>` is no longer wrongly marked optional. Consistent with `HashSet`/`HashMap`.
- **Wrong `Schematic::name()` values**: `i8` (`"i32"`→`"i8"`), `bool` (`"string"`→`"bool"`), `f32`/`f64` (`"string"`→`"f32"`/`"f64"`). Latent today (name isn't emitted into the schema) but incorrect, and they must be right before `name()` can feed components/`$ref` (#32).

## Not in this PR (remaining #37 items)
The macro-codegen bugs — tuple/newtype-struct panic, newtype-of-scalar enum variants, untagged multi-field tuple data loss — are left for a separate focused PR since they touch the derive's generated code.

## Verification
New `gotcha_core` unit tests for all three fixes; the full OpenAPI golden-file suite passes **unchanged** (no existing golden exercised these paths); `clippy --all-features --workspace -- -D warnings` and `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)