### PR TITLE
fix: task scheduling robustness (#40) + config profiles/required files (#27)

### DIFF
--- a/gotcha/src/config.rs
+++ b/gotcha/src/config.rs
@@ -54,6 +54,9 @@ pub struct ConfigState {
 pub struct ConfigBuilder {
     loader: ConfigLoader,
     state: ConfigState,
+    /// Required files (added via [`ConfigBuilder::file`]) that did not exist;
+    /// reported as an error at `build()` time.
+    missing_required: Vec<PathBuf>,
 }
 
 impl ConfigBuilder {
@@ -62,6 +65,7 @@ impl ConfigBuilder {
         Self {
             loader: ConfigLoader::new(),
             state: ConfigState::default(),
+            missing_required: Vec::new(),
         }
     }
 
@@ -72,12 +76,15 @@ impl ConfigBuilder {
         self
     }
 
-    /// Add required file source
+    /// Add a required file source. Unlike [`ConfigBuilder::file_optional`], a
+    /// missing file here causes `build()` to fail.
     pub fn file<P: AsRef<Path>>(mut self, path: P) -> Self {
         let path = path.as_ref().to_path_buf();
         self.state.file_paths.push(path.clone());
         if path.exists() {
             self.loader.add_source(FileSource::new(path));
+        } else {
+            self.missing_required.push(path);
         }
         self
     }
@@ -102,6 +109,12 @@ impl ConfigBuilder {
 
     /// Build configuration
     pub fn build<T: for<'de> Deserialize<'de>>(mut self) -> ConfigResult<T> {
+        if !self.missing_required.is_empty() {
+            return Err(ConfigError::Error(format!(
+                "required configuration file(s) not found: {:?}",
+                self.missing_required
+            )));
+        }
         if self.state.enable_vars {
             self.loader.enable_path_variable_processor();
             self.loader.enable_environment_variable_processor();
@@ -164,16 +177,16 @@ impl Config {
 pub struct GotchaConfigLoader;
 
 impl GotchaConfigLoader {
-    /// Load configuration from `configurations/application.toml` + the `APP`
-    /// environment prefix. Returns an error instead of panicking on failure.
-    ///
-    /// NOTE: `_profile` is not yet honored here — see the config-hardening issue.
-    pub fn load<T: for<'de> Deserialize<'de>>(_profile: Option<String>) -> ConfigResult<T> {
-        Config::builder()
-            .file_optional("configurations/application.toml")
-            .env("APP")
-            .enable_vars()
-            .build()
+    /// Load configuration from `configurations/application.toml`, then the
+    /// profile-specific `configurations/application_{profile}.toml` (if a profile
+    /// is given), then the `APP` environment prefix. Returns an error instead of
+    /// panicking on failure.
+    pub fn load<T: for<'de> Deserialize<'de>>(profile: Option<String>) -> ConfigResult<T> {
+        let mut builder = Config::builder().file_optional("configurations/application.toml");
+        if let Some(profile) = profile {
+            builder = builder.file_optional(format!("configurations/application_{profile}.toml"));
+        }
+        builder.env("APP").enable_vars().build()
     }
 }
 
@@ -201,5 +214,21 @@ mod tests {
         };
 
         assert_eq!(wrapper.application.name, "");
+    }
+
+    #[test]
+    fn required_missing_file_fails_to_build() {
+        let result: ConfigResult<TestConfig> = Config::builder().file("definitely-does-not-exist-abc123.toml").build();
+        assert!(result.is_err(), "a missing required file must fail the build");
+    }
+
+    #[test]
+    fn optional_missing_file_is_not_a_required_error() {
+        // A missing optional file must not trigger the required-file error (the config may
+        // still fail to deserialize for other reasons, but not because of this file).
+        let result: ConfigResult<TestConfig> = Config::builder().file_optional("definitely-does-not-exist-abc123.toml").build();
+        if let Err(ConfigError::Error(msg)) = &result {
+            assert!(!msg.contains("required configuration file"), "optional file wrongly treated as required: {msg}");
+        }
     }
 }

--- a/gotcha/src/task.rs
+++ b/gotcha/src/task.rs
@@ -61,13 +61,25 @@ where
         Self { context }
     }
 
+    /// Schedule a task on a cron expression.
+    ///
+    /// An invalid expression is reported (via `tracing::error!`) and the task is
+    /// simply not started, instead of panicking a detached task at the first tick.
     pub fn cron<F, FF>(&self, name: impl AsRef<str>, expression: String, task: F)
     where
         F: Fn(GotchaContext<T1, T2>) -> FF + Send + 'static,
         FF: Future<Output = ()> + Send + 'static,
     {
-        info!("starting cron task: {}", name.as_ref());
-        tokio::spawn(cron_proc_macro_wrapper(self.context.clone(), expression, task));
+        let name = name.as_ref().to_string();
+        let schedule = match Schedule::from_str(&expression) {
+            Ok(schedule) => schedule,
+            Err(e) => {
+                tracing::error!("cron task {name:?} has an invalid schedule {expression:?}: {e}; task not started");
+                return;
+            }
+        };
+        info!("starting cron task: {name}");
+        tokio::spawn(cron_proc_macro_wrapper(self.context.clone(), schedule, name, task));
     }
 
     pub fn interval<F, FF>(&self, name: impl AsRef<str>, interval: std::time::Duration, task: F)
@@ -75,31 +87,41 @@ where
         F: Fn(GotchaContext<T1, T2>) -> FF + Send + 'static,
         FF: Future<Output = ()> + Send + 'static,
     {
-        info!("starting interval task: {}", name.as_ref());
-        tokio::spawn(interval_proc_macro_wrapper(self.context.clone(), interval, task));
+        let name = name.as_ref().to_string();
+        info!("starting interval task: {name}");
+        tokio::spawn(interval_proc_macro_wrapper(self.context.clone(), interval, name, task));
     }
 }
 
-pub async fn cron_proc_macro_wrapper<T1, T2, F, FF>(context: GotchaContext<T1, T2>, expression: String, task: F)
+/// Run one task execution under supervision: if it panics, log it and keep the
+/// scheduler loop alive instead of silently killing the whole task.
+async fn run_supervised<FF>(name: &str, fut: FF)
+where
+    FF: Future<Output = ()> + Send + 'static,
+{
+    if let Err(join_error) = tokio::spawn(fut).await {
+        tracing::error!("scheduled task {name:?} panicked: {join_error}");
+    }
+}
+
+pub async fn cron_proc_macro_wrapper<T1, T2, F, FF>(context: GotchaContext<T1, T2>, schedule: Schedule, name: String, task: F)
 where
     T1: Clone + Send + Sync + 'static,
     T2: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de> + Default,
     F: Fn(GotchaContext<T1, T2>) -> FF + Send + 'static,
     FF: Future<Output = ()> + Send + 'static,
 {
-    let schedule: Schedule = Schedule::from_str(&expression).unwrap();
-    let scheduler = schedule.upcoming(Utc);
-
-    for next_trigger_time in scheduler {
+    for next_trigger_time in schedule.upcoming(Utc) {
         let now = Utc::now();
-        let duration = next_trigger_time - now;
-        tokio::time::sleep(duration.to_std().unwrap()).await;
-        let t = task(context.clone());
-        t.await
+        // A trigger computed in the past (clock skew, or a long previous run) would make
+        // `to_std()` fail — run immediately in that case rather than panicking.
+        let wait = (next_trigger_time - now).to_std().unwrap_or(std::time::Duration::ZERO);
+        tokio::time::sleep(wait).await;
+        run_supervised(&name, task(context.clone())).await;
     }
 }
 
-pub async fn interval_proc_macro_wrapper<T1, T2, F, FF>(context: GotchaContext<T1, T2>, interval: std::time::Duration, task: F)
+pub async fn interval_proc_macro_wrapper<T1, T2, F, FF>(context: GotchaContext<T1, T2>, interval: std::time::Duration, name: String, task: F)
 where
     T1: Clone + Send + Sync + 'static,
     T2: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de> + Default,
@@ -108,8 +130,7 @@ where
 {
     let mut interval = tokio::time::interval(interval);
     loop {
-        let _tick = interval.tick().await;
-        let t = task(context.clone());
-        t.await
+        interval.tick().await;
+        run_supervised(&name, task(context.clone())).await;
     }
 }


### PR DESCRIPTION
Two Tier-0 reliability fixes.

## #40 — task scheduler no longer panics on bad input or dies silently
- Invalid cron expressions are validated **up front** in `cron()`; the error is logged and the task isn't started, instead of `unwrap()`-panicking a *detached* task at the first tick (where it died silently).
- A trigger computed in the past no longer panics `Duration::to_std()` — it runs immediately (`unwrap_or(ZERO)`).
- Each execution runs under a `run_supervised` helper (`tokio::spawn` + await the `JoinHandle`), so a panicking task is **logged** and the scheduler loop survives.

## #27 — config profiles and required files now work
- `GotchaConfigLoader::load` honors `GOTCHA_ACTIVE_PROFILE` (loads `configurations/application_{profile}.toml`); the parameter was previously ignored.
- `ConfigBuilder::file` (required) now fails `build()` when the file is missing — genuinely distinct from `file_optional`, which they weren't before. (The panicking loader itself was already fixed in #42.)

## Verification
New config unit tests for the required-vs-optional distinction; task example still builds against the unchanged public `cron`/`interval` methods; `cargo build --workspace`, `clippy --all-features --workspace -- -D warnings`, and `cargo fmt --all -- --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)