### PR TITLE
fix(openapi): serde_json::Value 'any' schema (#18) + template all path params (#39)

### DIFF
--- a/gotcha/src/openapi/mod.rs
+++ b/gotcha/src/openapi/mod.rs
@@ -43,7 +43,10 @@ use crate::Responder;
 
 pub mod schematic;
 
-static PATH_VARIABLE_PATTERN: &str = r"\:[a-z]+(?:_[a-z]+)*";
+// Match `:name` path parameters up to the next `/`, mirroring axum (and
+// `ParameterProvider`). The previous `[a-z_]`-only pattern skipped `:userId`,
+// `:id2`, `:ID`, leaving them un-templated in the OpenAPI paths.
+static PATH_VARIABLE_PATTERN: &str = r":[^/]+";
 
 pub(crate) async fn openapi_html() -> impl Responder {
     Html(include_str!("../../statics/redoc.html"))
@@ -176,5 +179,8 @@ mod tests {
         assert_eq!(replace_path_variable("/users".to_string()), "/users");
         assert_eq!(replace_path_variable("/users/:id".to_string()), "/users/{id}");
         assert_eq!(replace_path_variable("/users/:id/:name".to_string()), "/users/{id}/{name}");
+        // camelCase, digits and uppercase are now templated too (previously skipped)
+        assert_eq!(replace_path_variable("/users/:userId".to_string()), "/users/{userId}");
+        assert_eq!(replace_path_variable("/items/:id2/:ID".to_string()), "/items/{id2}/{ID}");
     }
 }

--- a/gotcha_core/src/lib.rs
+++ b/gotcha_core/src/lib.rs
@@ -197,7 +197,7 @@ impl Schematic for chrono::NaiveDate {
 
 impl Schematic for serde_json::Value {
     fn name() -> &'static str {
-        "object"
+        "any"
     }
 
     fn required() -> bool {
@@ -208,8 +208,21 @@ impl Schematic for serde_json::Value {
         "object"
     }
 
-    fn format() -> Option<String> {
-        Some("json".to_string())
+    fn generate_schema() -> EnhancedSchema {
+        // `serde_json::Value` is an arbitrary JSON value (object, array, string, number,
+        // bool or null), so an empty schema (`{}`) — which matches anything — is the correct
+        // representation. Emitting `{"type":"object"}` made client generators read it as
+        // `Record<string, never>` (an empty object).
+        EnhancedSchema {
+            schema: Schema {
+                _type: None,
+                format: None,
+                nullable: None,
+                description: Self::doc(),
+                extras: Default::default(),
+            },
+            required: Self::required(),
+        }
     }
 }
 
@@ -431,5 +444,15 @@ mod tests {
         assert_eq!(<bool as Schematic>::name(), "bool");
         assert_eq!(<f32 as Schematic>::name(), "f32");
         assert_eq!(<f64 as Schematic>::name(), "f64");
+    }
+
+    #[test]
+    fn json_value_is_an_empty_any_schema() {
+        // `serde_json::Value` accepts any JSON, so its schema must be empty (`{}`), not
+        // `{"type":"object"}` (which reads as `Record<string, never>`).
+        let schema = <serde_json::Value as Schematic>::generate_schema();
+        let value = serde_json::to_value(&schema.schema).unwrap();
+        assert!(value.get("type").is_none(), "Value must not be typed: {value}");
+        assert!(value.get("format").is_none(), "Value must not have a format: {value}");
     }
 }


### PR DESCRIPTION
Two OpenAPI-output correctness fixes.

## #18 — `serde_json::Value` is `Record<string, never>`
`serde_json::Value` accepts **any** JSON, but it derived `{"type":"object","format":"json"}`, which client generators interpret as an empty object (`Record<string, never>`). It now derives an **empty schema `{}`** — the JSON-Schema/OpenAPI way to say "any value". Closes #18.

## #39 — path params with camelCase/digits/uppercase weren't templated
`PATH_VARIABLE_PATTERN` only matched `[a-z_]`, so `:userId`, `:id2`, `:ID` were left as-is in the generated OpenAPI paths, and it diverged from `ParameterProvider`'s `:([^/]+)`. It now matches `:name` up to the next `/`, mirroring axum.

## Verification
New unit tests for both; the full OpenAPI golden suite and integration tests pass unchanged (no golden pinned the old `Value` shape); clippy `-D warnings` and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)