### PR TITLE
fix(schematic): honor serde skip / default / skip_serializing_if (#38)

### DIFF
--- a/gotcha/tests/pass/openapi/serde_skip_default.rs
+++ b/gotcha/tests/pass/openapi/serde_skip_default.rs
@@ -1,0 +1,34 @@
+//! serde `skip` / `default` / `skip_serializing_if` are reflected in the schema:
+//! skipped fields disappear, and defaulted / conditionally-skipped fields are not
+//! marked required.
+
+use gotcha::Schematic;
+use serde::{Deserialize, Serialize};
+
+#[derive(Schematic, Serialize, Deserialize)]
+struct Item {
+    name: String,
+    #[serde(skip)]
+    internal: String,
+    #[serde(default)]
+    count: i32,
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    tag: String,
+}
+
+fn main() {
+    let schema = serde_json::to_value(Item::generate_schema().schema).unwrap();
+    let props = &schema["properties"];
+
+    // `skip` → the field is not part of the schema at all.
+    assert!(props.get("internal").is_none(), "skipped field must be absent");
+    assert!(props.get("name").is_some());
+    assert!(props.get("count").is_some());
+    assert!(props.get("tag").is_some());
+
+    let required = schema["required"].as_array().unwrap();
+    assert!(required.iter().any(|v| v == "name"), "plain field is required");
+    assert!(!required.iter().any(|v| v == "count"), "#[serde(default)] field must be optional");
+    assert!(!required.iter().any(|v| v == "tag"), "skip_serializing_if field must be optional");
+    assert!(!required.iter().any(|v| v == "internal"), "skipped field must not be required");
+}

--- a/gotcha_macro/src/schematic/named_struct.rs
+++ b/gotcha_macro/src/schematic/named_struct.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 
 use crate::schematic::ParameterStructFieldOpt;
-use crate::utils::{get_serde_name, has_serde_flatten, parse_serde_rename, AttributesExt, RenameAll};
+use crate::utils::{get_serde_name, has_serde_flatten, has_serde_skip, is_serde_optional, parse_serde_rename, AttributesExt, RenameAll};
 
 pub(crate) fn handler(
     ident: syn::Ident, doc: TokenStream2, fields: darling::ast::Fields<ParameterStructFieldOpt>, rename_all: Option<RenameAll>,
@@ -15,6 +15,12 @@ pub(crate) fn handler(
 
     for field in fields.fields.into_iter() {
         let field_ty = field.ty;
+
+        // `#[serde(skip)]` / `skip_serializing` / `skip_deserializing` fields are not part of
+        // the serialized payload, so they must not appear in the schema.
+        if has_serde_skip(&field.attrs) {
+            continue;
+        }
 
         if has_serde_flatten(&field.attrs) {
             // Flatten field: merge fields from the inner type at runtime
@@ -37,12 +43,20 @@ pub(crate) fn handler(
             } else {
                 quote! { None }
             };
+            // `#[serde(default)]` / `skip_serializing_if` make a field optional in the payload,
+            // so it must not be listed as required even if its type is otherwise required.
+            let optional_override = if is_serde_optional(&field.attrs) {
+                quote! { field_schema.required = false; }
+            } else {
+                quote! {}
+            };
             normal_fields_stream.push(quote! {
                 (
                     #field_name,
                     {
                         let mut field_schema = <#field_ty as ::gotcha_core::Schematic>::generate_schema();
                         field_schema.schema.description = #field_description;
+                        #optional_override
                         field_schema
                     }
                 )

--- a/gotcha_macro/src/utils.rs
+++ b/gotcha_macro/src/utils.rs
@@ -178,6 +178,41 @@ pub fn has_serde_flatten(attrs: &[Attribute]) -> bool {
     false
 }
 
+/// Run `pred` over each item inside every `#[serde(...)]` attribute; return true if any matches.
+fn serde_nested_any(attrs: &[Attribute], pred: impl Fn(&syn::Meta) -> bool) -> bool {
+    for attr in attrs {
+        if attr.path.is_ident("serde") {
+            if let Ok(nested) =
+                attr.parse_args_with(|input: syn::parse::ParseStream| syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated(input))
+            {
+                if nested.iter().any(&pred) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Whether a field is dropped by serde (`skip`, `skip_serializing`, `skip_deserializing`)
+/// and should therefore not appear in the schema.
+pub fn has_serde_skip(attrs: &[Attribute]) -> bool {
+    serde_nested_any(
+        attrs,
+        |meta| matches!(meta, syn::Meta::Path(path) if path.is_ident("skip") || path.is_ident("skip_serializing") || path.is_ident("skip_deserializing")),
+    )
+}
+
+/// Whether a field is effectively optional for serde — `default` (`default` or
+/// `default = "..."`) or `skip_serializing_if = "..."` — so it need not be present.
+pub fn is_serde_optional(attrs: &[Attribute]) -> bool {
+    serde_nested_any(attrs, |meta| match meta {
+        syn::Meta::Path(path) => path.is_ident("default"),
+        syn::Meta::NameValue(nv) => nv.path.is_ident("default") || nv.path.is_ident("skip_serializing_if"),
+        _ => false,
+    })
+}
+
 /// Parse serde rename_all attribute from container attributes
 pub fn parse_serde_rename_all(attrs: &[Attribute]) -> Option<RenameAll> {
     for attr in attrs {


### PR DESCRIPTION
The `Schematic` derive ignored several serde field attributes, so the generated schema disagreed with the actual JSON.

## Fixes
- **`#[serde(skip)]` / `skip_serializing` / `skip_deserializing`** — the field is now omitted from the schema entirely (it still appeared before).
- **`#[serde(default)]` and `#[serde(skip_serializing_if = "...")]`** — the field is no longer listed as `required`, since serde makes it optional in the payload.

Added `has_serde_skip` / `is_serde_optional` helpers (mirroring the existing `has_serde_flatten`).

## Verification
New trybuild test `serde_skip_default.rs`; the full OpenAPI golden suite + integration tests (incl. `test_flatten_advanced`, which uses these attrs) pass unchanged; clippy `-D warnings` and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)