### PR TITLE
feat(message): usable Messager with app-state access (closes #29)

### DIFF
--- a/examples/message/Cargo.toml
+++ b/examples/message/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gotcha = {version="0.3", path = "../../gotcha"}
+gotcha = {version="0.3", path = "../../gotcha", features = ["message"]}
 tokio = {version = "1", features = ["macros", 'rt-multi-thread']}
 serde = {version="1", features=["derive"]}

--- a/examples/message/src/main.rs
+++ b/examples/message/src/main.rs
@@ -1,39 +1,50 @@
-// #![allow(dead_code)]
-// use std::sync::Arc;
+//! Demonstrates the message system: a handler extracts `State<Messager<..>>`,
+//! sends a message that reads the application state, and that message in turn
+//! spawns a fire-and-forget background message.
 
-// use gotcha::{async_trait, Message, Messager,, Responder};
-// use serde::Deserialize;
+use gotcha::prelude::*;
+use gotcha::{async_trait, Message, Messager};
 
-// #[derive(Debug, Deserialize, Clone)]
-// struct Config {}
+#[derive(Clone, Default)]
+struct AppState {
+    greeting: String,
+}
 
-// pub(crate) struct HelloWorldMessage;
+/// Produces a greeting from the app state and kicks off a background message.
+struct Greet {
+    name: String,
+}
 
-// #[async_trait]
-// impl Message for HelloWorldMessage {
-//     type Output = String;
-//     async fn handle(self, messager: Arc<Messager>) -> Self::Output {
-//         messager.spawn(BackgroundTask).await;
-//         "hello world".to_string()
-//     }
-// }
+#[async_trait]
+impl Message<AppState, EmptyConfig> for Greet {
+    type Output = String;
+    async fn handle(self, messager: Messager<AppState, EmptyConfig>) -> String {
+        messager.spawn(LogGreeting(self.name.clone()));
+        format!("{}, {}!", messager.state().greeting, self.name)
+    }
+}
 
-// pub struct BackgroundTask;
+/// A fire-and-forget background message.
+struct LogGreeting(String);
 
-// #[async_trait]
-// impl Message for BackgroundTask {
-//     type Output = ();
-//     async fn handle(self, _messager: Arc<Messager>) -> Self::Output {
-//         // do backend task here
-//         println!("do backend task here");
-//     }
-// }
+#[async_trait]
+impl Message<AppState, EmptyConfig> for LogGreeting {
+    type Output = ();
+    async fn handle(self, _messager: Messager<AppState, EmptyConfig>) {
+        println!("[background] greeted {}", self.0);
+    }
+}
 
-// pub async fn hello_world() -> impl Responder {
-//     // messager.0.send(HelloWorldMessage).await
-// }
+async fn hello(State(messager): State<Messager<AppState, EmptyConfig>>) -> impl Responder {
+    messager.send(Greet { name: "world".to_string() }).await
+}
 
 #[tokio::main]
-async fn main() {
-    // OldGotchaApp::new().get("/", hello_world).done().serve("127.0.0.1", 8080).await
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    Gotcha::with_state::<AppState>()
+        .state(AppState { greeting: "Hello".to_string() })
+        .get("/", hello)
+        .run()
+        .await?;
+    Ok(())
 }

--- a/gotcha/src/message.rs
+++ b/gotcha/src/message.rs
@@ -1,39 +1,160 @@
 //! # Message Module
 //!
-//! This module provides a message handling system for Gotcha web applications.
-//! It allows for the asynchronous handling of messages and the spawning of tasks to handle them.
+//! A small message-dispatch system for background/async work with access to the
+//! application state.
 //!
-//! ## Features
+//! Implement [`Message`] for a unit of work, then dispatch it with a [`Messager`]:
+//! `send` awaits the result, `spawn` runs it fire-and-forget. The handler receives
+//! the `Messager`, so it can read the application state/config
+//! ([`Messager::state`] / [`Messager::context`]) and dispatch further messages.
 //!
-//! - Asynchronous message handling
-//! - Task spawning for message processing
-//! - Type-safe message handling
+//! The `Messager` is extractable in handlers as `State<Messager<S, C>>`, because it
+//! implements `FromRef<GotchaContext<S, C>>` (the context the framework injects as
+//! the axum state).
 //!
-use std::sync::Arc;
+//! ```ignore
+//! use gotcha::prelude::*;
+//! use gotcha::{async_trait, Message, Messager};
+//!
+//! struct Greet { name: String }
+//!
+//! #[async_trait]
+//! impl Message<AppState, AppConfig> for Greet {
+//!     type Output = String;
+//!     async fn handle(self, messager: Messager<AppState, AppConfig>) -> String {
+//!         format!("{}, {}!", messager.state().greeting, self.name)
+//!     }
+//! }
+//!
+//! async fn hello(State(messager): State<Messager<AppState, AppConfig>>) -> impl Responder {
+//!     messager.send(Greet { name: "world".into() }).await
+//! }
+//! ```
 
 use async_trait::async_trait;
-use axum::extract::State;
+use axum::extract::FromRef;
 
-pub struct Messager {}
+use crate::{GotchaConfig, GotchaContext};
 
-pub type MessagerWrapper = State<Messager>;
+/// A unit of asynchronous work, dispatched by a [`Messager`].
+///
+/// The `handle` method receives the `Messager`, so a message can read the
+/// application state and dispatch further messages.
+#[async_trait]
+pub trait Message<S, C>: Send + 'static
+where
+    S: Clone + Send + Sync + 'static,
+    C: GotchaConfig,
+{
+    /// The value produced by handling this message.
+    type Output: Send + 'static;
 
-impl Messager {
-    pub async fn send<T: Message>(self: Arc<Self>, msg: T) -> T::Output {
-        msg.handle(self).await
-    }
+    /// Handle the message, producing its output.
+    async fn handle(self, messager: Messager<S, C>) -> Self::Output;
+}
 
-    pub async fn spawn<T>(self: Arc<Self>, msg: T)
-    where
-        T: Message + 'static,
-        T::Output: Send,
-    {
-        tokio::spawn(msg.handle(self));
+/// Dispatches [`Message`]s. It carries the application [`GotchaContext`], so
+/// messages can access the application state and configuration.
+///
+/// Extract it in a handler with `State<Messager<S, C>>`.
+pub struct Messager<S, C>
+where
+    S: Clone + Send + Sync + 'static,
+    C: GotchaConfig,
+{
+    context: GotchaContext<S, C>,
+}
+
+impl<S, C> Clone for Messager<S, C>
+where
+    S: Clone + Send + Sync + 'static,
+    C: GotchaConfig,
+{
+    fn clone(&self) -> Self {
+        Self { context: self.context.clone() }
     }
 }
 
-#[async_trait]
-pub trait Message {
-    type Output;
-    async fn handle(self, messager: Arc<Messager>) -> Self::Output;
+impl<S, C> Messager<S, C>
+where
+    S: Clone + Send + Sync + 'static,
+    C: GotchaConfig,
+{
+    /// Create a `Messager` bound to an application context.
+    pub fn new(context: GotchaContext<S, C>) -> Self {
+        Self { context }
+    }
+
+    /// The application context (state + config).
+    pub fn context(&self) -> &GotchaContext<S, C> {
+        &self.context
+    }
+
+    /// The application state.
+    pub fn state(&self) -> &S {
+        &self.context.state
+    }
+
+    /// Dispatch a message and await its output.
+    pub async fn send<M: Message<S, C>>(&self, message: M) -> M::Output {
+        message.handle(self.clone()).await
+    }
+
+    /// Dispatch a message as a detached background task (fire-and-forget).
+    pub fn spawn<M: Message<S, C, Output = ()>>(&self, message: M) {
+        let messager = self.clone();
+        tokio::spawn(async move { message.handle(messager).await });
+    }
+}
+
+impl<S, C> FromRef<GotchaContext<S, C>> for Messager<S, C>
+where
+    S: Clone + Send + Sync + 'static,
+    C: GotchaConfig,
+{
+    fn from_ref(context: &GotchaContext<S, C>) -> Self {
+        Messager::new(context.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ConfigWrapper, EmptyConfig};
+
+    #[derive(Clone, Default)]
+    struct AppState {
+        greeting: String,
+    }
+
+    struct Greet {
+        name: String,
+    }
+
+    #[async_trait]
+    impl Message<AppState, EmptyConfig> for Greet {
+        type Output = String;
+        async fn handle(self, messager: Messager<AppState, EmptyConfig>) -> String {
+            format!("{}, {}!", messager.state().greeting, self.name)
+        }
+    }
+
+    #[test]
+    fn send_dispatches_and_reads_state() {
+        let context = GotchaContext {
+            config: ConfigWrapper {
+                basic: Default::default(),
+                application: EmptyConfig::default(),
+            },
+            state: AppState { greeting: "Hello".to_string() },
+        };
+        let messager = Messager::new(context);
+
+        let output = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(messager.send(Greet { name: "world".to_string() }));
+
+        assert_eq!(output, "Hello, world!");
+    }
 }


### PR DESCRIPTION
Replaces the non-functional `message` stub with a working, state-aware dispatcher. Closes #29; addresses #8 (data context for messages).

## Before
`Messager` was an empty struct; `send`/`spawn` required `Arc<Self>` while `MessagerWrapper = State<Messager>` held it by value; it wasn't wired into the context (no `FromRef`), and the example was entirely commented out — so it couldn't be used at all.

## Now
- **`Messager<S, C>` carries the `GotchaContext`** → messages read app state/config via `messager.state()` / `messager.context()`.
- **`impl FromRef<GotchaContext<S, C>> for Messager<S, C>`** → extract it directly in a handler as `State<Messager<S, C>>`.
- **`send(msg).await`** returns the message's `Output`; **`spawn(msg)`** runs it fire-and-forget. The handler receives the `Messager`, so a message can dispatch further messages.

```rust
#[async_trait]
impl Message<AppState, AppConfig> for Greet {
    type Output = String;
    async fn handle(self, m: Messager<AppState, AppConfig>) -> String {
        m.spawn(LogIt(self.name.clone()));            // background work
        format!("{}, {}!", m.state().greeting, self.name)  // read app state
    }
}

async fn hello(State(m): State<Messager<AppState, AppConfig>>) -> impl Responder {
    m.send(Greet { name: "world".into() }).await
}
```

## Verification
Unit test (`send` dispatches + reads state → `"Hello, world!"`); the `message` example is now a real compiling program (feature enabled); `clippy --all-features --workspace -- -D warnings` and `cargo fmt --all -- --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)