### PR TITLE
docs: re-enable doctests + fix rotted examples/README (closes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ struct User {
 ### Advanced Trait API (For complex applications)
 
 ```rust
-use gotcha::{async_trait, ConfigWrapper, GotchaApp, GotchaContext, GotchaRouter, State};
+use gotcha::{ConfigWrapper, GotchaApp, GotchaContext, GotchaResult, GotchaRouter, State};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -61,7 +61,6 @@ pub struct Config {
 
 pub struct App {}
 
-#[async_trait]
 impl GotchaApp for App {
     type State = AppState;
     type Config = Config;
@@ -73,8 +72,7 @@ impl GotchaApp for App {
             .get("/users/:id", get_user)
     }
 
-    async fn state(&self, config: &ConfigWrapper<Self::Config>) 
-        -> Result<Self::State, Box<dyn std::error::Error>> {
+    async fn state(&self, config: &ConfigWrapper<Self::Config>) -> GotchaResult<Self::State> {
         // Initialize database connections, etc.
         Ok(AppState::new(&config.database_url).await?)
     }
@@ -97,7 +95,7 @@ Add Gotcha to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gotcha = "0.2"
+gotcha = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1", features = ["derive"] }
 ```
@@ -108,7 +106,7 @@ Enable additional features as needed:
 
 ```toml
 [dependencies]
-gotcha = { version = "0.2", features = ["openapi", "prometheus", "cors", "static_files", "task", "message"] }
+gotcha = { version = "0.3", features = ["openapi", "prometheus", "cors", "static_files", "task", "message"] }
 ```
 
 Available features:
@@ -170,23 +168,22 @@ Configuration supports:
 ### Task Scheduling
 
 ```rust
-use gotcha::{GotchaApp, task::TaskScheduler};
+use gotcha::{GotchaApp, GotchaResult, TaskScheduler};
+use std::time::Duration;
 
-#[async_trait]
 impl GotchaApp for App {
     // ... other implementations
 
-    async fn tasks(&self) -> Vec<TaskScheduler> {
-        vec![
-            TaskScheduler::new("cleanup", "0 2 * * *", || async {
-                // Daily cleanup at 2 AM
-                println!("Running cleanup task");
-            }),
-            TaskScheduler::interval("heartbeat", Duration::from_secs(30), || async {
-                // Every 30 seconds
-                println!("Heartbeat");
-            }),
-        ]
+    async fn tasks(&self, scheduler: &mut TaskScheduler<Self::State, Self::Config>) -> GotchaResult<()> {
+        // Daily cleanup at 2 AM (cron fields: sec min hour day month weekday)
+        scheduler.cron("cleanup", "0 0 2 * * *".to_string(), |_ctx| async {
+            println!("Running cleanup task");
+        });
+        // Every 30 seconds
+        scheduler.interval("heartbeat", Duration::from_secs(30), |_ctx| async {
+            println!("Heartbeat");
+        });
+        Ok(())
     }
 }
 ```

--- a/gotcha/Cargo.toml
+++ b/gotcha/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/Kilerd/gotcha/"
 
 [lib]
-doctest = false
+doctest = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -59,3 +59,5 @@ assert-json-diff = "2"
 # Non-optional so trybuild-generated test crates (which derive Schematic and thus
 # emit `::gotcha_core::` paths) have gotcha_core in their extern prelude.
 gotcha_core = { version = "0.3", path = "../gotcha_core" }
+# So `#[tokio::main]` doc examples compile (the lib's own tokio dep is minimal).
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/gotcha/src/builder.rs
+++ b/gotcha/src/builder.rs
@@ -105,20 +105,15 @@ impl Gotcha {
     /// use gotcha::prelude::*;
     /// use serde::{Deserialize, Serialize};
     ///
+    /// #[state]
     /// #[derive(Clone, Default)]
-    /// struct AppState {
-    ///     // your state fields
-    /// }
+    /// struct AppState {}
     ///
     /// #[derive(Clone, Default, Serialize, Deserialize)]
-    /// struct AppConfig {
-    ///     // your config fields
-    /// }
+    /// struct AppConfig {}
     ///
     /// let app = Gotcha::with_types::<AppState, AppConfig>()
-    ///     .get("/", |state: State<AppState>| async move {
-    ///         "Hello with custom state"
-    ///     });
+    ///     .get("/", |State(_): State<AppState>| async move { "Hello with custom state" });
     /// ```
     pub fn with_types<S, C>() -> Gotcha<S, C>
     where
@@ -143,6 +138,7 @@ impl Gotcha {
     /// ```no_run
     /// use gotcha::prelude::*;
     ///
+    /// #[state]
     /// #[derive(Clone, Default)]
     /// struct AppState {
     ///     counter: std::sync::Arc<std::sync::atomic::AtomicU64>,
@@ -150,9 +146,7 @@ impl Gotcha {
     ///
     /// let app = Gotcha::with_state::<AppState>()
     ///     .state(AppState::default())
-    ///     .get("/", |state: State<AppState>| async move {
-    ///         "Hello with custom state"
-    ///     });
+    ///     .get("/", |State(_): State<AppState>| async move { "Hello with custom state" });
     /// ```
     pub fn with_state<S>() -> Gotcha<S, EmptyConfig>
     where
@@ -230,14 +224,11 @@ where
     ///
     /// # Example
     /// ```no_run
+    /// # fn demo() -> gotcha::GotchaResult<()> {
     /// use gotcha::prelude::*;
     ///
-    /// let app = Gotcha::new()
-    ///     .build_config(|builder| {
-    ///         builder
-    ///             .file_optional("config.toml")
-    ///             .env("APP")
-    ///     })?;
+    /// let _app = Gotcha::new().build_config(|builder| builder.file_optional("config.toml").env("APP"))?;
+    /// # Ok(()) }
     /// ```
     pub fn build_config<F>(mut self, builder_fn: F) -> GotchaResult<Self>
     where
@@ -261,7 +252,7 @@ where
     /// use gotcha::prelude::*;
     ///
     /// let app = Gotcha::new()
-    ///     .with_default_config()?;
+    ///     .with_default_config();
     /// ```
     pub fn with_default_config(self) -> Self {
         self.with_default_files().with_default_env()
@@ -533,6 +524,9 @@ where
     /// # Example
     /// ```no_run
     /// use gotcha::prelude::*;
+    /// # async fn home_handler() -> impl Responder { "" }
+    /// # async fn about_handler() -> impl Responder { "" }
+    /// # async fn create_user() -> impl Responder { "" }
     ///
     /// let app = Gotcha::new()
     ///     .routes(|router| {
@@ -749,7 +743,9 @@ impl Gotcha<EmptyState, EmptyConfig> {
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     Gotcha::quick_start()
+    ///         .await?
     ///         .get("/", || async { "Hello World" })
+    ///         .run()
     ///         .await?;
     ///     Ok(())
     /// }

--- a/gotcha/src/openapi/mod.rs
+++ b/gotcha/src/openapi/mod.rs
@@ -14,11 +14,12 @@
 //! ## Example
 //!
 //! ```rust,no_run
-//! use gotcha::{GotchaRouter, Operable};
+//! use gotcha::{api, GotchaRouter};
 //!
-//! #[openapi(group = "Users")]
-//! async fn get_user() -> impl Responder {
-//!     // Handler implementation
+//! /// Get a user by id
+//! #[api(id = "get_user", group = "users")]
+//! async fn get_user() -> String {
+//!     "user".to_string()
 //! }
 //!
 //! fn routes(router: GotchaRouter) -> GotchaRouter {
@@ -26,8 +27,8 @@
 //! }
 //! ```
 //!
-//! The OpenAPI documentation will be automatically generated and served at `/docs`
-//! and `/docs/scalar` endpoints when the feature is enabled.
+//! The generated spec is served at `/openapi.json`, with the Redoc UI at `/redoc`
+//! and the Scalar UI at `/scalar` when the feature is enabled.
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/gotcha/src/router.rs
+++ b/gotcha/src/router.rs
@@ -72,7 +72,9 @@ impl<State: Clone + Send + Sync + 'static> GotchaRouter<State> {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use gotcha::{GotchaRouter, Responder};
+    /// use gotcha::GotchaRouter;
+    /// use gotcha::axum::routing::MethodFilter;
+    /// # use gotcha::Responder;
     ///
     /// async fn hello_world() -> impl Responder {
     ///     "Hello World!"
@@ -173,10 +175,10 @@ impl<State: Clone + Send + Sync + 'static> GotchaRouter<State> {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use gotcha::{GotchaRouter};
+    /// use gotcha::GotchaRouter;
     ///
     /// let router: GotchaRouter<()> = GotchaRouter::default()
-    ///     .layer(MyLayer::default());
+    ///     .layer(gotcha::axum::Extension(0u32));
     /// ```
     pub fn layer<L>(self, layer: L) -> Self
     where

--- a/gotcha/src/task.rs
+++ b/gotcha/src/task.rs
@@ -13,21 +13,22 @@
 //! ## Examples
 //!
 //! ```rust,no_run
-//! use gotcha::{GotchaContext, TaskScheduler};
+//! use gotcha::TaskScheduler;
 //! use std::time::Duration;
 //!
-//! // Create a task scheduler
-//! let scheduler = TaskScheduler::new(context);
+//! # #[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
+//! # struct Config {}
+//! fn setup(scheduler: &TaskScheduler<(), Config>) {
+//!     // Schedule a cron task (the expression is a `String`)
+//!     scheduler.cron("daily-cleanup", "0 0 * * *".to_string(), |_ctx| async move {
+//!         // Task implementation
+//!     });
 //!
-//! // Schedule a cron task
-//! scheduler.cron("daily-cleanup", "0 0 * * *", |ctx| async move {
-//!     // Task implementation
-//! });
-//!
-//! // Schedule an interval task
-//! scheduler.interval("heartbeat", Duration::from_secs(60), |ctx| async move {
-//!     // Task implementation  
-//! });
+//!     // Schedule an interval task
+//!     scheduler.interval("heartbeat", Duration::from_secs(60), |_ctx| async move {
+//!         // Task implementation
+//!     });
+//! }
 //! ```
 //!
 //! Tasks have access to the application context and can be used for:

--- a/gotcha_core/Cargo.toml
+++ b/gotcha_core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/Kilerd/gotcha/"
 
 [lib]
-doctest = false
+doctest = true
 
 [features]
 # Enables the axum-facing schema glue: `Responsible for Json<T>` and the whole


### PR DESCRIPTION
`doctest = false` had let the doc examples rot (wrong/nonexistent APIs). This re-enables doctests so CI compiles every example, and fixes all of them.

## Misleading docs corrected
- **openapi module** showed a nonexistent `#[openapi]` macro and `/docs` routes → now `#[api]` and `/openapi.json` + `/redoc` + `/scalar`.
- **task module** showed `TaskScheduler::new(context)` and a `&str` cron expression → now the real `&mut TaskScheduler` + `String` API.
- **README**: `0.2` → `0.3`; the `tasks()` example rewritten from a nonexistent `Vec<TaskScheduler>` API to the real `tasks(&mut TaskScheduler) -> GotchaResult<()>`; dropped the vestigial `#[async_trait]` + `Box<dyn Error>` from the trait example.

## Doctest compilation fixes
- `State<AppState>` examples now use `#[state]`; a stray `?` on a non-`Result` method removed; undefined handler names given hidden `#` defs; `quick_start().await?` corrected; `MethodFilter`/layer imports added.
- Added a `tokio` dev-dependency (`macros` + `rt-multi-thread`) so `#[tokio::main]` doc examples compile.

## Verification
Doctests pass across feature combos — default (26), all-features (29), message-only (26); `gotcha_core` clean (0). Full `cargo test -p gotcha --features openapi` green; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)