### PR TITLE
feat(schematic): documentation field attributes for #[schematic(...)] (closes #35)

### DIFF
--- a/gotcha/tests/pass/openapi/schematic_field_attrs.rs
+++ b/gotcha/tests/pass/openapi/schematic_field_attrs.rs
@@ -1,0 +1,59 @@
+//! `#[schematic(...)]` field attributes attach schema *documentation* metadata
+//! (title/description/example/default/format). An explicit `description` overrides the
+//! doc comment, and `example`/`default` keep their JSON type.
+//!
+//! Validation constraints (min/max, length, pattern, …) are intentionally NOT here — they
+//! belong to request validation (issue #9) so a rule is written once.
+
+use gotcha::Schematic;
+use serde::{Deserialize, Serialize};
+
+#[derive(Schematic, Serialize, Deserialize)]
+struct Product {
+    /// this doc comment must be overridden by the schematic description
+    #[schematic(title = "Name", description = "The product name", example = "Widget")]
+    name: String,
+
+    #[schematic(format = "email")]
+    contact: String,
+
+    // `example` / `default` keep their JSON type instead of becoming strings.
+    #[schematic(example = 42, default = 10)]
+    quantity: u32,
+}
+
+// The same `#[schematic(...)]` handling must reach fields inside enum variants.
+#[derive(Schematic, Serialize, Deserialize)]
+enum Event {
+    Created {
+        /// this doc comment must be overridden too
+        #[schematic(description = "when it happened", format = "date-time")]
+        at: String,
+    },
+}
+
+fn main() {
+    let schema = serde_json::to_value(Product::generate_schema().schema).unwrap();
+    let props = &schema["properties"];
+
+    // Metadata, with description overriding the doc comment.
+    let name = &props["name"];
+    assert_eq!(name["title"], "Name");
+    assert_eq!(name["description"], "The product name", "explicit description overrides doc comment");
+    assert_eq!(name["example"], "Widget");
+
+    // `format` lands on the schema's dedicated field.
+    assert_eq!(props["contact"]["format"], "email");
+
+    // example/default keep their numeric JSON type.
+    let quantity = &props["quantity"];
+    assert!(quantity["example"].is_number(), "typed example stays a number, not the string \"42\"");
+    assert_eq!(quantity["example"], 42);
+    assert_eq!(quantity["default"], 10);
+
+    // Enum-variant fields get the same treatment (asserted via the serialized schema so the
+    // test does not couple to the exact tagged-union nesting).
+    let event = serde_json::to_string(&Event::generate_schema().schema).unwrap();
+    assert!(event.contains("when it happened"), "schematic description reaches enum variant fields: {event}");
+    assert!(event.contains("date-time"), "schematic format reaches enum variant fields: {event}");
+}

--- a/gotcha_macro/src/lib.rs
+++ b/gotcha_macro/src/lib.rs
@@ -71,6 +71,31 @@ pub fn api(args: TokenStream, input_stream: TokenStream) -> TokenStream {
 /// This derive macro automatically implements the `Schematic` trait,
 /// which generates OpenAPI JSON schemas for request and response types.
 ///
+/// ## Field attributes
+///
+/// Individual fields can be annotated with `#[schematic(...)]` to enrich the
+/// generated schema with *documentation* metadata. All keys are optional:
+/// `title`, `description`, `example`, `default`, `format`.
+///
+/// An explicit `description` overrides the field's doc comment, and `example` /
+/// `default` preserve their JSON type (`example = 42` stays a number, not `"42"`).
+///
+/// Validation constraints (min/max, length, regex, …) are intentionally *not* part of
+/// `#[schematic]`; they are handled by request validation as a single source of truth, so
+/// a constraint is never written twice.
+///
+/// ```rust,ignore
+/// #[derive(Schematic, Serialize, Deserialize)]
+/// struct CreateUserRequest {
+///     #[schematic(description = "User's full name", example = "Ada Lovelace")]
+///     name: String,
+///     #[schematic(format = "email")]
+///     email: String,
+///     #[schematic(default = 18)]
+///     age: u8,
+/// }
+/// ```
+///
 /// ## Example
 ///
 /// ```rust,ignore

--- a/gotcha_macro/src/schematic/adjacent_tagged_enum.rs
+++ b/gotcha_macro/src/schematic/adjacent_tagged_enum.rs
@@ -81,10 +81,13 @@ pub(crate) fn handler(
                         let field_ident_str = field_ident.to_string();
                         let field_rename = parse_serde_rename(&field.attrs);
                         let field_name = get_serde_name(&field_ident_str, field_rename.as_deref(), None);
+                        let (field_description, customizations) = field.schema_customizations();
                         let field_ty = &field.ty;
                         Some(quote! {
                             {
-                                let field_schema = <#field_ty as ::gotcha_core::Schematic>::generate_schema();
+                                let mut field_schema = <#field_ty as ::gotcha_core::Schematic>::generate_schema();
+                                field_schema.schema.description = #field_description;
+                                #( #customizations )*
                                 content_properties.insert(#field_name.to_string(), field_schema.schema.to_value());
                                 if field_schema.required {
                                     content_required.push(#field_name.to_string());

--- a/gotcha_macro/src/schematic/external_tagged_enum.rs
+++ b/gotcha_macro/src/schematic/external_tagged_enum.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 
 use crate::schematic::ParameterEnumVariantOpt;
-use crate::utils::{get_serde_name, parse_serde_rename, AttributesExt, RenameAll};
+use crate::utils::{get_serde_name, parse_serde_rename, RenameAll};
 
 pub(crate) fn handler(
     ident: syn::Ident, doc: TokenStream2, variants: Vec<ParameterEnumVariantOpt>, rename_all: Option<RenameAll>,
@@ -32,12 +32,8 @@ pub(crate) fn handler(
                     .fields
                     .into_iter()
                     .map(|field| {
+                        let (field_description, customizations) = field.schema_customizations();
                         let field_ty = field.ty.clone();
-                        let field_description = if let Some(doc) = field.attrs.get_doc() {
-                            quote! { Some(#doc.to_string()) }
-                        } else {
-                            quote! {None}
-                        };
                         if let Some(ident) = field.ident.as_ref() {
                             let field_ident_str = ident.to_string();
                             let field_rename = parse_serde_rename(&field.attrs);
@@ -45,6 +41,7 @@ pub(crate) fn handler(
                             quote! {
                                 let mut field_schema = <#field_ty as ::gotcha_core::Schematic>::generate_schema();
                                 field_schema.schema.description = #field_description;
+                                #( #customizations )*
                                 properties.insert(#field_name.to_string(), field_schema.schema.to_value());
                                 if field_schema.required {
                                     properties_required_fields.push(#field_name.to_string());

--- a/gotcha_macro/src/schematic/mod.rs
+++ b/gotcha_macro/src/schematic/mod.rs
@@ -89,13 +89,96 @@ pub(crate) struct ParameterOpts {
     attrs: Vec<syn::Attribute>,
 }
 
+/// A literal JSON value (`= 42`, `= "x"`, `= true`) whose JSON type is preserved. Used for
+/// `example` / `default` so a numeric example stays a number instead of becoming a string.
+#[derive(Debug, Clone)]
+struct SchemaValue(TokenStream2);
+
+impl darling::FromMeta for SchemaValue {
+    fn from_value(value: &syn::Lit) -> darling::Result<Self> {
+        let tokens = match value {
+            syn::Lit::Str(v) => {
+                let v = v.value();
+                quote! { ::gotcha_core::serde_json::Value::from(#v) }
+            }
+            syn::Lit::Int(v) => {
+                let v = v.base10_parse::<i64>().map_err(darling::Error::from)?;
+                quote! { ::gotcha_core::serde_json::Value::from(#v) }
+            }
+            syn::Lit::Float(v) => {
+                let v = v.base10_parse::<f64>().map_err(darling::Error::from)?;
+                quote! { ::gotcha_core::serde_json::Value::from(#v) }
+            }
+            syn::Lit::Bool(v) => {
+                let v = v.value;
+                quote! { ::gotcha_core::serde_json::Value::from(#v) }
+            }
+            _ => return Err(darling::Error::unexpected_lit_type(value)),
+        };
+        Ok(SchemaValue(tokens))
+    }
+}
+
 #[derive(Debug, FromField)]
-#[darling(attributes(parameter), forward_attrs(allow, doc, cfg, serde))]
+#[darling(attributes(schematic), forward_attrs(allow, doc, cfg, serde))]
 pub(crate) struct ParameterStructFieldOpt {
     ident: Option<syn::Ident>,
     ty: syn::Type,
     attrs: Vec<syn::Attribute>,
-    // add more validator
+
+    // `#[schematic(...)]` field customizations — pure schema *documentation* only. darling
+    // treats `Option<_>` fields as optional automatically, so an absent attribute maps to `None`.
+    //
+    // Validation constraints (min/max, length, pattern, multiple_of, items, …) are deliberately
+    // NOT here: those belong to `#[validation(...)]` (issue #9) as the single source of truth for
+    // both runtime request validation and the schema, so a constraint is never written twice.
+    title: Option<String>,
+    description: Option<String>,
+    example: Option<SchemaValue>,
+    default: Option<SchemaValue>,
+    format: Option<String>,
+}
+
+impl ParameterStructFieldOpt {
+    /// Builds the `description` token and the list of `#[schematic(...)]` customization
+    /// statements for this field. Each statement mutates a local `field_schema` binding
+    /// (its `.schema.format` / `.schema.extras`). An explicit `#[schematic(description = "...")]`
+    /// overrides the doc comment.
+    pub(crate) fn schema_customizations(&self) -> (TokenStream2, Vec<TokenStream2>) {
+        // Builds a statement that inserts a JSON-Schema keyword into `field_schema.schema.extras`.
+        fn extra(key: &str, value: TokenStream2) -> TokenStream2 {
+            quote! {
+                field_schema.schema.extras.insert(#key.to_string(), ::gotcha_core::serde_json::to_value(#value).unwrap());
+            }
+        }
+
+        let description = if let Some(desc) = &self.description {
+            quote! { Some(#desc.to_string()) }
+        } else if let Some(doc) = self.attrs.get_doc() {
+            quote! { Some(#doc.to_string()) }
+        } else {
+            quote! { None }
+        };
+
+        let mut customizations: Vec<TokenStream2> = Vec::new();
+        if let Some(format) = &self.format {
+            customizations.push(quote! { field_schema.schema.format = Some(#format.to_string()); });
+        }
+        if let Some(v) = &self.title {
+            customizations.push(extra("title", quote! { #v }));
+        }
+        // `example` / `default` keep their JSON type (`SchemaValue` already builds a `Value`).
+        if let Some(v) = &self.example {
+            let value = &v.0;
+            customizations.push(quote! { field_schema.schema.extras.insert("example".to_string(), #value); });
+        }
+        if let Some(v) = &self.default {
+            let value = &v.0;
+            customizations.push(quote! { field_schema.schema.extras.insert("default".to_string(), #value); });
+        }
+
+        (description, customizations)
+    }
 }
 
 #[derive(Debug, FromVariant)]

--- a/gotcha_macro/src/schematic/named_struct.rs
+++ b/gotcha_macro/src/schematic/named_struct.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 
 use crate::schematic::ParameterStructFieldOpt;
-use crate::utils::{get_serde_name, has_serde_flatten, has_serde_skip, is_serde_optional, parse_serde_rename, AttributesExt, RenameAll};
+use crate::utils::{get_serde_name, has_serde_flatten, has_serde_skip, is_serde_optional, parse_serde_rename, RenameAll};
 
 pub(crate) fn handler(
     ident: syn::Ident, doc: TokenStream2, fields: darling::ast::Fields<ParameterStructFieldOpt>, rename_all: Option<RenameAll>,
@@ -14,7 +14,7 @@ pub(crate) fn handler(
     let mut flatten_schema_stream: Vec<TokenStream2> = Vec::new();
 
     for field in fields.fields.into_iter() {
-        let field_ty = field.ty;
+        let field_ty = field.ty.clone();
 
         // `#[serde(skip)]` / `skip_serializing` / `skip_deserializing` fields are not part of
         // the serialized payload, so they must not appear in the schema.
@@ -38,11 +38,6 @@ pub(crate) fn handler(
             let ident_str = field.ident.as_ref().unwrap().to_string();
             let rename = parse_serde_rename(&field.attrs);
             let field_name = get_serde_name(&ident_str, rename.as_deref(), rename_all);
-            let field_description = if let Some(doc) = field.attrs.get_doc() {
-                quote! { Some(#doc.to_string()) }
-            } else {
-                quote! { None }
-            };
             // `#[serde(default)]` / `skip_serializing_if` make a field optional in the payload,
             // so it must not be listed as required even if its type is otherwise required.
             let optional_override = if is_serde_optional(&field.attrs) {
@@ -50,6 +45,10 @@ pub(crate) fn handler(
             } else {
                 quote! {}
             };
+            // Description (an explicit `#[schematic(description = ...)]` overrides the doc comment)
+            // plus the `#[schematic(...)]` validation/metadata customizations.
+            let (field_description, customizations) = field.schema_customizations();
+
             normal_fields_stream.push(quote! {
                 (
                     #field_name,
@@ -57,6 +56,7 @@ pub(crate) fn handler(
                         let mut field_schema = <#field_ty as ::gotcha_core::Schematic>::generate_schema();
                         field_schema.schema.description = #field_description;
                         #optional_override
+                        #( #customizations )*
                         field_schema
                     }
                 )

--- a/gotcha_macro/src/schematic/tagged_enum.rs
+++ b/gotcha_macro/src/schematic/tagged_enum.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 
 use crate::schematic::ParameterEnumVariantOpt;
-use crate::utils::{get_serde_name, parse_serde_rename, AttributesExt, RenameAll};
+use crate::utils::{get_serde_name, parse_serde_rename, RenameAll};
 
 pub(crate) fn handler(
     ident: syn::Ident, doc: TokenStream2, variants: Vec<ParameterEnumVariantOpt>, rename_all: Option<RenameAll>, tag_name: String,
@@ -21,12 +21,7 @@ pub(crate) fn handler(
                 .fields
                 .into_iter()
                 .map(|field| {
-                    // doc code gen
-                    let field_description = if let Some(doc) = field.attrs.get_doc() {
-                        quote! { Some(#doc.to_string()) }
-                    } else {
-                        quote! {None}
-                    };
+                    let (field_description, customizations) = field.schema_customizations();
                     let field_ty = field.ty.clone();
 
                     if let Some(ident) = field.ident.as_ref() {
@@ -37,6 +32,7 @@ pub(crate) fn handler(
                         quote! {
                             let mut field_schema = <#field_ty as ::gotcha_core::Schematic>::generate_schema();
                             field_schema.schema.description = #field_description;
+                            #( #customizations )*
                             properties.insert(#field_name.to_string(), field_schema.schema.to_value());
                             if field_schema.required {
                                 properties_required_fields.push(#field_name.to_string());

--- a/gotcha_macro/src/schematic/untagged_enum.rs
+++ b/gotcha_macro/src/schematic/untagged_enum.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 
 use crate::schematic::ParameterEnumVariantOpt;
-use crate::utils::{get_serde_name, parse_serde_rename, AttributesExt, RenameAll};
+use crate::utils::{get_serde_name, parse_serde_rename, RenameAll};
 
 pub(crate) fn handler(
     ident: syn::Ident, doc: TokenStream2, variants: Vec<ParameterEnumVariantOpt>, rename_all: Option<RenameAll>,
@@ -56,11 +56,7 @@ pub(crate) fn handler(
                     .fields
                     .into_iter()
                     .map(|field| {
-                        let field_description = if let Some(doc) = field.attrs.get_doc() {
-                            quote! { Some(#doc.to_string()) }
-                        } else {
-                            quote! { None }
-                        };
+                        let (field_description, customizations) = field.schema_customizations();
                         let field_ty = field.ty.clone();
                         let field_ident_str = field.ident.as_ref().map(|i| i.to_string()).unwrap_or_default();
                         let field_rename = parse_serde_rename(&field.attrs);
@@ -68,6 +64,7 @@ pub(crate) fn handler(
                         quote! {
                             let mut field_schema = <#field_ty as ::gotcha_core::Schematic>::generate_schema();
                             field_schema.schema.description = #field_description;
+                            #( #customizations )*
                             properties.insert(#field_name.to_string(), field_schema.schema.to_value());
                             if field_schema.required {
                                 properties_required_fields.push(#field_name.to_string());


### PR DESCRIPTION
## Problem

`#[derive(Schematic)]` registered `attributes(schematic)` but the darling parser read `attributes(parameter)` and only pulled out `ident`/`ty`/`attrs` — so `#[schematic(...)]` was **silently ignored**. There was no working field-customization attribute at all. Closes #35.

## Scope: documentation only

Following the discussion on #9, this PR keeps `#[schematic(...)]` to pure schema **documentation** and leaves validation constraints to request validation, so a rule is never written twice.

`#[schematic(...)]` now works on struct fields **and** struct-style enum variants (external/internal/adjacent-tagged + untagged), via a shared `ParameterStructFieldOpt::schema_customizations` helper that also de-duplicates the per-handler doc-comment logic.

Supported keys (all optional): `title`, `description`, `example`, `default`, `format`.

```rust
#[derive(Schematic, Serialize, Deserialize)]
struct CreateUserRequest {
    #[schematic(description = "User's full name", example = "Ada Lovelace")]
    name: String,
    #[schematic(format = "email")]
    email: String,
    #[schematic(default = 18)]
    age: u8,
}
```

- `description` overrides the field's doc comment.
- `example` / `default` **preserve their JSON type** via a small `SchemaValue` `FromMeta`, so `example = 42` emits the number `42`, not the string `"42"`.

## Out of scope by design (→ #9)

Validation keywords — `minimum`/`maximum`/`exclusive_*`/`multiple_of`/`min_length`/`max_length`/`pattern`/`min_items`/`max_items`/`unique_items` — are **not** here. They belong to `#[validation(...)]` (#9) as the single source of truth: written once, they will drive both the runtime `Validator` and the OpenAPI schema keywords. This avoids the duplication of stating each constraint twice.

## Tests

New trybuild golden `tests/pass/openapi/schematic_field_attrs.rs` asserts metadata, description-overrides-doc, type-preserving `example`/`default`, and that the same handling reaches enum-variant fields.

Verified locally: `cargo test -p gotcha_macro --all-features`, `cargo test -p gotcha --features openapi` (incl. golden JSON), `cargo clippy --all-features --workspace` (clean), `cargo fmt --all -- --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)