### PR TITLE
feat(openapi): document the error side of Result<T, E> (closes #33)

### DIFF
--- a/gotcha/tests/pass/openapi/result_responses.rs
+++ b/gotcha/tests/pass/openapi/result_responses.rs
@@ -1,0 +1,41 @@
+//! A `Result<Json<T>, E>` handler return type documents both the success response (from `T`)
+//! and the error response (from `E`, as the OpenAPI `default` response). Previously the error
+//! variant was dropped entirely.
+
+use gotcha::{Json, Responsible, Schematic};
+use serde::{Deserialize, Serialize};
+
+#[derive(Schematic, Serialize, Deserialize)]
+struct User {
+    id: u32,
+}
+
+/// User lookup failure
+#[derive(Schematic, Serialize, Deserialize)]
+struct ApiError {
+    message: String,
+}
+
+fn main() {
+    let responses = <Result<Json<User>, ApiError> as Responsible>::response();
+
+    // Success side is still there.
+    assert!(responses.data.contains_key("200"), "success (200) response is documented");
+
+    // Error side is now documented as the `default` response, carrying `ApiError`'s schema.
+    let default = responses.default.expect("error variant must be documented as the default response");
+    if let gotcha::oas::Referenceable::Data(response) = default {
+        // Description is taken from the error type's doc comment.
+        assert!(response.description.contains("User lookup failure"), "error description comes from the doc comment: {:?}", response.description);
+        let content = response.content.expect("error response has a body");
+        assert!(content.contains_key("application/json"), "error body is application/json");
+    } else {
+        panic!("expected an inline default response");
+    }
+
+    // axum's `(StatusCode, Json<E>)` error idiom is documented too — the error type `E`'s body is
+    // recorded even though the status code is only known at runtime.
+    let tuple = <Result<Json<User>, (gotcha::axum::http::StatusCode, Json<ApiError>)> as Responsible>::response();
+    assert!(tuple.data.contains_key("200"), "tuple-error idiom keeps the success response");
+    assert!(tuple.default.is_some(), "tuple-error idiom documents the error as the default response");
+}

--- a/gotcha_core/src/responsible.rs
+++ b/gotcha_core/src/responsible.rs
@@ -65,12 +65,60 @@ where
     }
 }
 
+/// Documents the error side of a `Result<T, E>` handler return type.
+///
+/// It contributes the error response(s) to the operation's [`Responses`] — as the OpenAPI
+/// `default` response, which covers any status code not otherwise listed. Implemented for any
+/// `E: Schematic` and for axum's `(StatusCode, Json<E>)` idiom; custom error types can implement
+/// it directly.
+pub trait ErrorResponsible {
+    fn error_responses(responses: &mut Responses);
+}
+
+/// A `default` response whose JSON body is `E`'s schema (description taken from `E`'s doc comment).
+fn schema_error_response<E: Schematic>() -> Referenceable<Response> {
+    let schema = E::generate_schema();
+    Referenceable::Data(Response {
+        description: E::doc().unwrap_or_else(|| "error response".to_string()),
+        headers: None,
+        content: Some(BTreeMap::from([(
+            "application/json".to_string(),
+            MediaType {
+                schema: Some(Referenceable::Data(schema.schema)),
+                example: None,
+                examples: None,
+                encoding: None,
+            },
+        )])),
+        links: None,
+    })
+}
+
+impl<E: Schematic> ErrorResponsible for E {
+    fn error_responses(responses: &mut Responses) {
+        responses.default = Some(schema_error_response::<E>());
+    }
+}
+
+/// axum's `(StatusCode, Json<E>)` error idiom documents `E`'s body. The status is a runtime value,
+/// so the body is recorded as the `default` response.
+#[cfg(feature = "axum")]
+impl<E: Schematic> ErrorResponsible for (axum::http::StatusCode, axum::Json<E>) {
+    fn error_responses(responses: &mut Responses) {
+        responses.default = Some(schema_error_response::<E>());
+    }
+}
+
 impl<T, E> Responsible for Result<T, E>
 where
     T: Responsible,
+    E: ErrorResponsible,
 {
     fn response() -> Responses {
-        // todo: add error response
-        T::response()
+        // Success side (`200`, ...) comes from `T`; the error side `E` documents its own response,
+        // so a `Result<Json<T>, ApiError>` handler documents both.
+        let mut responses = T::response();
+        E::error_responses(&mut responses);
+        responses
     }
 }


### PR DESCRIPTION
Closes #33. `Responsible for Result<T, E>` dropped the error variant (`// todo`), so every fallible handler was documented with only a `200`.

## Change

Adds an `ErrorResponsible` trait that documents the error type as the OpenAPI **`default`** response (the spec's catch-all for any status code not otherwise listed). It's implemented for:

- **any `E: Schematic`** — a named error type, e.g. `Result<Json<T>, ApiError>`;
- **axum's `(StatusCode, Json<E>)` idiom** — the status is a runtime value, so the `E` body is documented.

The `Result` impl now bounds `E: ErrorResponsible` and merges success + error:

```rust
async fn get_user() -> Result<Json<User>, (StatusCode, Json<ApiError>)> { ... }
// documents BOTH the 200 (User) and the default error (ApiError)
```

## Why this shape

The first attempt bounded `E: Schematic` directly — but that broke the `(StatusCode, Json<E>)` tuple idiom used by the `testing-guide` example (a tuple isn't `Schematic`). `ErrorResponsible` mirrors the existing `Responsible` blanket+specific pattern, so it stays coherent, documents both the named-error and tuple idioms, and is **non-breaking** (the only `#[api]` handlers returning `Result` in the repo use the tuple idiom, and their `ErrorResponse` is `Schematic`). Custom error types can `impl ErrorResponsible` directly.

Using `default` avoids needing `E`'s HTTP status at compile time. No specialization involved.

## Deferred (noted in the issue)

Explicit per-response status codes/descriptions via `#[api]`, non-JSON content types, response headers, and `()` → `204`.

## Test

`tests/pass/openapi/result_responses.rs` asserts both a named-error `Result<Json<User>, ApiError>` and the `(StatusCode, Json<ApiError>)` idiom document the `200` and a `default` error response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)