### PR TITLE
feat(openapi): typed header and cookie parameters (closes #36)

### DIFF
--- a/gotcha/Cargo.toml
+++ b/gotcha/Cargo.toml
@@ -36,6 +36,9 @@ http = "0.2"
 oas = { version = "0.1", optional = true }
 mofa = "0.1"
 axum = {version = "0.7", default-features = false, features = ["form", "json", "query", "multipart"]}
+# For `TypedHeader<T>`: axum 0.7 moved it out of axum proper. Only the `typed-header` feature is
+# enabled, which brings in the `headers` crate and nothing else.
+axum-extra = { version = "0.9", default-features = false, features = ["typed-header"] }
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
 inventory = "0.3.15"

--- a/gotcha/src/lib.rs
+++ b/gotcha/src/lib.rs
@@ -118,7 +118,11 @@ pub use oas;
 pub use crate::message::{Message, Messager};
 #[cfg(feature = "openapi")]
 pub use crate::openapi::Operable;
+pub use crate::params::{Cookie, CookieParam, Header, HeaderParam, ParamRejection};
 pub use crate::validation::{Valid, ValidRejection};
+/// axum's typed-header extractor and the header types it works with. `TypedHeader<T>` documents
+/// itself as an OpenAPI header parameter (the name comes from `headers::Header`).
+pub use axum_extra::{headers, TypedHeader};
 /// Derive and trait for request validation (re-exported from the `validator` crate).
 /// Use with the [`Valid`] extractor.
 pub use validator::Validate;
@@ -128,6 +132,7 @@ pub mod config;
 pub mod error;
 #[cfg(feature = "openapi")]
 pub mod openapi;
+pub mod params;
 pub mod prelude;
 pub mod router;
 

--- a/gotcha/src/params.rs
+++ b/gotcha/src/params.rs
@@ -1,0 +1,313 @@
+//! Typed header and cookie parameters.
+//!
+//! axum's [`HeaderMap`](axum::http::HeaderMap) is untyped: a handler can read any header from it,
+//! but nothing about it can be documented. [`Header<T>`] and [`Cookie<T>`] name a single parameter
+//! through the [`HeaderParam`] / [`CookieParam`] traits, so the same declaration both extracts the
+//! value and documents it as an OpenAPI `header` / `cookie` parameter.
+//!
+//! ```ignore
+//! use gotcha::{Header, HeaderParam, Schematic};
+//!
+//! #[derive(Schematic)]
+//! struct RequestId(String);
+//!
+//! impl HeaderParam for RequestId {
+//!     const NAME: &'static str = "x-request-id";
+//!     const DESCRIPTION: Option<&'static str> = Some("Correlation id propagated across services");
+//!     fn parse(raw: &str) -> Result<Self, String> {
+//!         Ok(RequestId(raw.to_string()))
+//!     }
+//! }
+//!
+//! async fn handler(Header(id): Header<RequestId>) -> String {
+//!     id.0
+//! }
+//! ```
+
+use async_trait::async_trait;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+/// A type that can be parsed from one named HTTP header.
+pub trait HeaderParam: Sized {
+    /// The header name, matched case-insensitively (HTTP header names are case-insensitive).
+    const NAME: &'static str;
+    /// Whether the request is rejected when the header is absent. Defaults to `true`.
+    const REQUIRED: bool = true;
+    /// Description for the generated OpenAPI parameter. Worth setting when the type is a newtype
+    /// wrapper, since those are transparent in the schema and their doc comment does not survive.
+    const DESCRIPTION: Option<&'static str> = None;
+    /// Parse the raw header value, returning a message describing why it was rejected.
+    fn parse(raw: &str) -> Result<Self, String>;
+    /// The value used when the header is absent and [`REQUIRED`](Self::REQUIRED) is `false`.
+    fn missing() -> Option<Self> {
+        None
+    }
+}
+
+/// A type that can be parsed from one named cookie.
+pub trait CookieParam: Sized {
+    /// The cookie name (case-sensitive, unlike header names).
+    const NAME: &'static str;
+    /// Whether the request is rejected when the cookie is absent. Defaults to `true`.
+    const REQUIRED: bool = true;
+    /// Description for the generated OpenAPI parameter. Worth setting when the type is a newtype
+    /// wrapper, since those are transparent in the schema and their doc comment does not survive.
+    const DESCRIPTION: Option<&'static str> = None;
+    /// Parse the raw cookie value, returning a message describing why it was rejected.
+    fn parse(raw: &str) -> Result<Self, String>;
+    /// The value used when the cookie is absent and [`REQUIRED`](Self::REQUIRED) is `false`.
+    fn missing() -> Option<Self> {
+        None
+    }
+}
+
+/// Extracts the header named by `T`'s [`HeaderParam`] impl, and documents it as an OpenAPI
+/// `header` parameter.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Header<T>(pub T);
+
+/// Extracts the cookie named by `T`'s [`CookieParam`] impl, and documents it as an OpenAPI
+/// `cookie` parameter.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Cookie<T>(pub T);
+
+impl<T> std::ops::Deref for Header<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> std::ops::Deref for Cookie<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+/// Rejection produced by [`Header`] and [`Cookie`].
+#[derive(Debug)]
+pub enum ParamRejection {
+    /// A required parameter was absent.
+    Missing { kind: &'static str, name: &'static str },
+    /// The parameter was present but could not be parsed.
+    Invalid { kind: &'static str, name: &'static str, message: String },
+    /// The header value was not valid UTF-8, so it cannot be parsed as text.
+    NotText { kind: &'static str, name: &'static str },
+}
+
+impl IntoResponse for ParamRejection {
+    fn into_response(self) -> Response {
+        let body = match self {
+            ParamRejection::Missing { kind, name } => format!("missing required {kind} parameter `{name}`"),
+            ParamRejection::Invalid { kind, name, message } => format!("invalid {kind} parameter `{name}`: {message}"),
+            ParamRejection::NotText { kind, name } => format!("{kind} parameter `{name}` is not valid UTF-8"),
+        };
+        (StatusCode::BAD_REQUEST, body).into_response()
+    }
+}
+
+/// Shared by both extractors: turn an optional raw value into `T`, honouring `REQUIRED`.
+fn resolve<T>(
+    kind: &'static str, name: &'static str, required: bool, raw: Option<&str>, parse: impl FnOnce(&str) -> Result<T, String>,
+    missing: impl FnOnce() -> Option<T>,
+) -> Result<T, ParamRejection> {
+    match raw {
+        Some(raw) => parse(raw).map_err(|message| ParamRejection::Invalid { kind, name, message }),
+        None if !required => missing().ok_or(ParamRejection::Missing { kind, name }),
+        None => Err(ParamRejection::Missing { kind, name }),
+    }
+}
+
+#[async_trait]
+impl<S, T> FromRequestParts<S> for Header<T>
+where
+    T: HeaderParam,
+    S: Send + Sync,
+{
+    type Rejection = ParamRejection;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let raw = match parts.headers.get(T::NAME) {
+            // A header can carry arbitrary bytes; only text can be parsed.
+            Some(value) => Some(value.to_str().map_err(|_| ParamRejection::NotText { kind: "header", name: T::NAME })?),
+            None => None,
+        };
+        resolve("header", T::NAME, T::REQUIRED, raw, T::parse, T::missing).map(Header)
+    }
+}
+
+#[async_trait]
+impl<S, T> FromRequestParts<S> for Cookie<T>
+where
+    T: CookieParam,
+    S: Send + Sync,
+{
+    type Rejection = ParamRejection;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let cookies = parts
+            .headers
+            .get(axum::http::header::COOKIE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        let raw = cookie_value(cookies, T::NAME);
+        resolve("cookie", T::NAME, T::REQUIRED, raw, T::parse, T::missing).map(Cookie)
+    }
+}
+
+/// Find `name` in a `Cookie` header value (`a=1; b=2`).
+fn cookie_value<'a>(header: &'a str, name: &str) -> Option<&'a str> {
+    header.split(';').find_map(|pair| {
+        let (key, value) = pair.split_once('=')?;
+        (key.trim() == name).then(|| value.trim())
+    })
+}
+
+#[cfg(feature = "openapi")]
+mod openapi {
+    use gotcha_core::oas::{Parameter, ParameterIn, Referenceable, RequestBody};
+    use gotcha_core::Schematic;
+
+    use super::{Cookie, CookieParam, Header, HeaderParam};
+    use crate::{Either, ParameterProvider};
+
+    fn parameter<T: Schematic>(name: &'static str, _in: ParameterIn, required: bool, description: Option<&'static str>) -> Either<Vec<Parameter>, RequestBody> {
+        let schema = T::generate_schema();
+        Either::Left(vec![Parameter {
+            name: name.to_string(),
+            _in,
+            // An explicit `DESCRIPTION` wins; otherwise fall back to the type's own doc comment
+            // (which a transparent newtype wrapper will not have).
+            description: description.map(str::to_string).or_else(T::doc),
+            required: Some(required),
+            deprecated: None,
+            allow_empty_value: None,
+            style: None,
+            explode: None,
+            allow_reserved: None,
+            schema: Some(Referenceable::Data(schema.schema)),
+            example: None,
+            examples: None,
+            content: None,
+        }])
+    }
+
+    impl<T: HeaderParam + Schematic> ParameterProvider for Header<T> {
+        fn generate(_url: String) -> Either<Vec<Parameter>, RequestBody> {
+            parameter::<T>(T::NAME, ParameterIn::Header, T::REQUIRED, T::DESCRIPTION)
+        }
+    }
+
+    impl<T: CookieParam + Schematic> ParameterProvider for Cookie<T> {
+        fn generate(_url: String) -> Either<Vec<Parameter>, RequestBody> {
+            parameter::<T>(T::NAME, ParameterIn::Cookie, T::REQUIRED, T::DESCRIPTION)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct RequestId(String);
+
+    impl HeaderParam for RequestId {
+        const NAME: &'static str = "x-request-id";
+        fn parse(raw: &str) -> Result<Self, String> {
+            if raw.is_empty() {
+                return Err("must not be empty".to_string());
+            }
+            Ok(RequestId(raw.to_string()))
+        }
+    }
+
+    struct Session(String);
+
+    impl CookieParam for Session {
+        const NAME: &'static str = "session";
+        fn parse(raw: &str) -> Result<Self, String> {
+            Ok(Session(raw.to_string()))
+        }
+    }
+
+    struct Tenant(String);
+
+    impl HeaderParam for Tenant {
+        const NAME: &'static str = "x-tenant";
+        const REQUIRED: bool = false;
+        fn parse(raw: &str) -> Result<Self, String> {
+            Ok(Tenant(raw.to_string()))
+        }
+        fn missing() -> Option<Self> {
+            Some(Tenant("default".to_string()))
+        }
+    }
+
+    fn parts_with(headers: &[(&str, &str)]) -> Parts {
+        let mut builder = axum::http::Request::builder();
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        builder.body(axum::body::Body::empty()).unwrap().into_parts().0
+    }
+
+    #[tokio::test]
+    async fn header_is_extracted() {
+        let mut parts = parts_with(&[("x-request-id", "abc123")]);
+        let Header(id) = Header::<RequestId>::from_request_parts(&mut parts, &()).await.unwrap();
+        assert_eq!(id.0, "abc123");
+    }
+
+    #[tokio::test]
+    async fn header_name_is_case_insensitive() {
+        let mut parts = parts_with(&[("X-Request-Id", "abc123")]);
+        assert!(Header::<RequestId>::from_request_parts(&mut parts, &()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn missing_required_header_is_rejected() {
+        let mut parts = parts_with(&[]);
+        let rejection = Header::<RequestId>::from_request_parts(&mut parts, &()).await.err().expect("must be rejected");
+        assert!(matches!(rejection, ParamRejection::Missing { .. }));
+        assert_eq!(rejection.into_response().status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn unparseable_header_is_rejected() {
+        let mut parts = parts_with(&[("x-request-id", "")]);
+        let rejection = Header::<RequestId>::from_request_parts(&mut parts, &()).await.err().expect("must be rejected");
+        assert!(matches!(rejection, ParamRejection::Invalid { .. }));
+    }
+
+    #[tokio::test]
+    async fn optional_header_falls_back() {
+        let mut parts = parts_with(&[]);
+        let Header(tenant) = Header::<Tenant>::from_request_parts(&mut parts, &()).await.unwrap();
+        assert_eq!(tenant.0, "default");
+    }
+
+    #[tokio::test]
+    async fn cookie_is_extracted_from_the_cookie_header() {
+        let mut parts = parts_with(&[("cookie", "theme=dark; session=xyz789; lang=en")]);
+        let Cookie(session) = Cookie::<Session>::from_request_parts(&mut parts, &()).await.unwrap();
+        assert_eq!(session.0, "xyz789");
+    }
+
+    #[tokio::test]
+    async fn missing_cookie_is_rejected() {
+        let mut parts = parts_with(&[("cookie", "theme=dark")]);
+        assert!(Cookie::<Session>::from_request_parts(&mut parts, &()).await.is_err());
+    }
+
+    #[test]
+    fn cookie_values_are_split_on_pairs() {
+        assert_eq!(cookie_value("a=1; b=2", "b"), Some("2"));
+        assert_eq!(cookie_value("a=1", "missing"), None);
+        // A cookie value may itself contain `=`.
+        assert_eq!(cookie_value("token=abc=def", "token"), Some("abc=def"));
+    }
+}

--- a/gotcha/tests/pass/openapi/header_cookie_params.rs
+++ b/gotcha/tests/pass/openapi/header_cookie_params.rs
@@ -1,0 +1,111 @@
+//! Typed header and cookie parameters are documented as OpenAPI `header` / `cookie` parameters,
+//! and axum's untyped `HeaderMap` is accepted by `#[api]` handlers (it documents nothing).
+
+use gotcha::axum::http::HeaderMap;
+use gotcha::{api, headers, openapi::Operable, Cookie, CookieParam, Header, HeaderParam, Schematic, TypedHeader};
+use serde::{Deserialize, Serialize};
+
+#[derive(Schematic, Serialize, Deserialize)]
+struct RequestId(String);
+
+impl HeaderParam for RequestId {
+    const NAME: &'static str = "x-request-id";
+    const DESCRIPTION: Option<&'static str> = Some("Correlation id propagated across services");
+    fn parse(raw: &str) -> Result<Self, String> {
+        Ok(RequestId(raw.to_string()))
+    }
+}
+
+#[derive(Schematic, Serialize, Deserialize)]
+struct Session(String);
+
+impl CookieParam for Session {
+    const NAME: &'static str = "session";
+    const REQUIRED: bool = false;
+    fn parse(raw: &str) -> Result<Self, String> {
+        Ok(Session(raw.to_string()))
+    }
+    fn missing() -> Option<Self> {
+        Some(Session(String::new()))
+    }
+}
+
+#[api(id = "whoami")]
+async fn whoami(Header(id): Header<RequestId>, Cookie(session): Cookie<Session>) -> String {
+    format!("{} {}", id.0, session.0)
+}
+
+/// The untyped map is allowed, it just contributes no documented parameters.
+#[api(id = "raw_headers")]
+async fn raw_headers(_headers: HeaderMap) -> String {
+    "ok".to_string()
+}
+
+/// axum's own typed headers need no extra declaration — `headers::Header` carries the name —
+/// and wrapping one in `Option` makes it an optional parameter.
+#[api(id = "typed_headers")]
+async fn typed_headers(
+    TypedHeader(agent): TypedHeader<headers::UserAgent>, host: Option<TypedHeader<headers::Host>>,
+) -> String {
+    format!("{} {:?}", agent.as_str(), host.is_some())
+}
+
+fn extract<H, T>(_handler: H) -> &'static Operable
+where
+    H: gotcha::axum::handler::Handler<T, ()>,
+    T: 'static,
+{
+    gotcha::router::extract_operable::<H, T, ()>().expect("handler is registered")
+}
+
+fn main() {
+    let operation = extract(whoami).generate("/whoami".to_owned());
+    let params = operation.parameters.expect("handler has parameters");
+
+    let named = |name: &str| {
+        params
+            .iter()
+            .find_map(|p| match p {
+                gotcha::oas::Referenceable::Data(p) if p.name == name => Some(p.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("`{name}` is documented: {params:?}"))
+    };
+
+    // The header parameter lands in the right place, is required, and carries its description.
+    let header = named("x-request-id");
+    assert!(matches!(header._in, gotcha::oas::ParameterIn::Header));
+    assert_eq!(header.required, Some(true));
+    assert_eq!(header.description.as_deref(), Some("Correlation id propagated across services"));
+    // A newtype wrapper is transparent, so the schema is the inner type's.
+    let schema = serde_json::to_value(header.schema.unwrap()).unwrap();
+    assert_eq!(schema["type"], "string");
+
+    // The cookie parameter is separate from headers, and `REQUIRED = false` is reflected.
+    let cookie = named("session");
+    assert!(matches!(cookie._in, gotcha::oas::ParameterIn::Cookie));
+    assert_eq!(cookie.required, Some(false));
+
+    // `HeaderMap` compiles as a handler argument and documents nothing.
+    let raw = extract(raw_headers).generate("/raw".to_owned());
+    assert!(raw.parameters.unwrap_or_default().is_empty(), "the untyped map documents no parameters");
+
+    // axum's typed headers name themselves; `Option<..>` marks the parameter optional.
+    let typed = extract(typed_headers).generate("/typed".to_owned());
+    let typed_params: Vec<_> = typed
+        .parameters
+        .expect("typed headers are documented")
+        .into_iter()
+        .filter_map(|p| match p {
+            gotcha::oas::Referenceable::Data(p) => Some(p),
+            _ => None,
+        })
+        .collect();
+
+    let agent = typed_params.iter().find(|p| p.name == "user-agent").expect("user-agent documented");
+    assert!(matches!(agent._in, gotcha::oas::ParameterIn::Header));
+    assert_eq!(agent.required, Some(true));
+
+    let host = typed_params.iter().find(|p| p.name == "host").expect("host documented");
+    assert_eq!(host.required, Some(false), "Option<TypedHeader<..>> is not required");
+}

--- a/gotcha_core/Cargo.toml
+++ b/gotcha_core/Cargo.toml
@@ -14,12 +14,15 @@ doctest = true
 # `ParameterProvider` family (impls for Path/Json/Query/State/Extension/Request/Multipart).
 # Off by default so a crate that only needs the Schematic schema layer stays free of
 # axum/regex/either. The `gotcha` crate turns this on.
-axum = ["dep:axum", "dep:regex", "dep:either"]
+axum = ["dep:axum", "dep:axum-extra", "dep:regex", "dep:either"]
 
 [dependencies]
 gotcha_macro = { version = "0.3", path = "../gotcha_macro" }
 oas = "0.1"
 axum = { version = "0.7", default-features = false, features = ["json", "query", "multipart"], optional = true }
+# `TypedHeader<T>` lives here since axum 0.7; the impl must be in this crate because that is where
+# `ParameterProvider` is defined (orphan rule).
+axum-extra = { version = "0.9", default-features = false, features = ["typed-header"], optional = true }
 regex = { version = "1", optional = true }
 either = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"] }

--- a/gotcha_core/src/parameter.rs
+++ b/gotcha_core/src/parameter.rs
@@ -167,6 +167,45 @@ impl<T> ParameterProvider for State<T> {}
 
 impl<T> ParameterProvider for Extension<T> {}
 
+/// The whole header map is untyped, so there is nothing to document — but a handler must still be
+/// able to take it. Individual headers are documented with `gotcha::Header<T>`.
+impl ParameterProvider for axum::http::HeaderMap {}
+
+/// axum's own typed headers document themselves: [`axum_extra::headers::Header`] already carries
+/// the header name, so `TypedHeader<UserAgent>` needs no extra declaration. Header values are text
+/// on the wire, so the schema is a string.
+impl<T: axum_extra::headers::Header> ParameterProvider for axum_extra::TypedHeader<T> {
+    fn generate(_url: String) -> Either<Vec<Parameter>, RequestBody> {
+        let schema = Schema {
+            _type: Some("string".to_string()),
+            format: None,
+            nullable: None,
+            description: None,
+            extras: Default::default(),
+        };
+        Either::Left(vec![build_param(T::name().as_str().to_string(), ParameterIn::Header, true, schema, None)])
+    }
+}
+
+/// axum treats `Option<E>` as "extract `E`, or `None` if it isn't there", so the parameters `E`
+/// contributes are documented but no longer required.
+impl<T: ParameterProvider> ParameterProvider for Option<T> {
+    fn generate(url: String) -> Either<Vec<Parameter>, RequestBody> {
+        match T::generate(url) {
+            Either::Left(params) => Either::Left(
+                params
+                    .into_iter()
+                    .map(|mut param| {
+                        param.required = Some(false);
+                        param
+                    })
+                    .collect(),
+            ),
+            body => body,
+        }
+    }
+}
+
 impl ParameterProvider for Request {}
 
 impl ParameterProvider for axum::extract::multipart::Multipart {


### PR DESCRIPTION
Closes #36 — the last open item on the Tier 2 roadmap.

## Two problems

1. `ParameterProvider` only mapped `ParameterIn::Path` / `Query`, so header and cookie parameters couldn't be documented.
2. **`HeaderMap` had no impl at all** — an `#[api]` handler couldn't even take it: `the trait bound HeaderMap: ParameterProvider is not satisfied`.

## Three ways to declare one, all documented

**1. `TypedHeader<T>` — axum's own, works out of the box.** `headers::Header` already carries the name, so nothing extra is needed:

```rust
async fn handler(TypedHeader(agent): TypedHeader<headers::UserAgent>) -> String { ... }
// documents: { name: "user-agent", in: "header", required: true, schema: { type: "string" } }
```

axum 0.7 moved `TypedHeader` to axum-extra, so that's a new dependency — with **only** its `typed-header` feature enabled (which brings the `headers` crate and nothing else). `TypedHeader` and `headers` are re-exported from `gotcha`.

The impl had to go in **`gotcha_core`**, not `gotcha`: `ParameterProvider` is defined there, and both the trait and `TypedHeader` are foreign to `gotcha` → E0117.

**2. `Header<T>` / `Cookie<T>` — for custom names, parsing, or optionality.**

```rust
impl HeaderParam for RequestId {
    const NAME: &'static str = "x-request-id";
    const DESCRIPTION: Option<&'static str> = Some("Correlation id propagated across services");
    fn parse(raw: &str) -> Result<Self, String> { Ok(RequestId(raw.to_string())) }
}

async fn handler(Header(id): Header<RequestId>) -> String { id.0 }
```

- `REQUIRED` (default `true`) drives **both** the runtime rejection and the documented `required` flag; `missing()` gives optional params a fallback.
- `DESCRIPTION` is needed because a newtype wrapper is transparent in the schema (by design, since #45), so its doc comment doesn't survive — without it there'd be no way to describe such a parameter. Falls back to `doc()` when unset.
- Headers match case-insensitively, cookies case-sensitively (per spec). Cookies are parsed from the `Cookie` header without a new dependency (values containing `=` handled).
- Bad input → `400` naming the parameter.

**3. `HeaderMap` — the untyped case.** Now compiles; documents nothing, which is the honest outcome.

## Also: `ParameterProvider for Option<T>`

axum's idiom for an optional extractor is `Option<TypedHeader<..>>`, which previously didn't compile either. It now documents `T`'s parameters with `required: false`.

## Verification

Run locally: full `gotcha` openapi suite, builds **with and without** the `openapi` feature, `cargo clippy --all-features --workspace`, `cargo fmt --check`.

8 unit tests (extraction, case-insensitivity, missing / unparseable / optional-fallback, cookie splitting) plus `tests/pass/openapi/header_cookie_params.rs` asserting header, cookie, `TypedHeader` and `Option<TypedHeader<..>>` all land correctly, and that `HeaderMap` compiles and contributes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)