### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Add Gotcha to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gotcha = "0.3"
+gotcha = "0.4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1", features = ["derive"] }
 ```
@@ -119,7 +119,7 @@ Enable additional features as needed:
 
 ```toml
 [dependencies]
-gotcha = { version = "0.3", features = ["openapi", "prometheus", "cors", "static_files", "task"] }
+gotcha = { version = "0.4", features = ["openapi", "prometheus", "cors", "static_files", "task"] }
 ```
 
 Available features:

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gotcha = {version="0.3", path = "../../gotcha"}
+gotcha = {version="0.4", path = "../../gotcha"}
 tokio = {version = "1", features = ["macros", 'rt-multi-thread']}
 serde = {version="1", features=["derive"]}

--- a/examples/configuration/Cargo.toml
+++ b/examples/configuration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gotcha = {version="0.3", path = "../../gotcha", features = ["http1"]}
+gotcha = {version="0.4", path = "../../gotcha", features = ["http1"]}
 serde = {version="1", features=["derive"]}
 serde_json = "1"
 tokio = {version = "1", features = ["macros", 'rt-multi-thread', 'fs']}

--- a/examples/message/Cargo.toml
+++ b/examples/message/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gotcha = {version="0.3", path = "../../gotcha"}
+gotcha = {version="0.4", path = "../../gotcha"}
 tokio = {version = "1", features = ["macros", 'rt-multi-thread']}
 serde = {version="1", features=["derive"]}

--- a/examples/openapi/Cargo.toml
+++ b/examples/openapi/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gotcha = {version="0.3", path = "../../gotcha", features = ["openapi", "http1"]}
+gotcha = {version="0.4", path = "../../gotcha", features = ["openapi", "http1"]}
 # Required because `#[derive(Schematic)]` expands to `::gotcha_core::` paths.
 gotcha_core = { path = "../../gotcha_core" }
 tokio = {version = "1", features = ["macros", 'rt-multi-thread']}

--- a/examples/task/Cargo.toml
+++ b/examples/task/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gotcha = {version="0.3", path = "../../gotcha", features = ["task", "http1"]}
+gotcha = {version="0.4", path = "../../gotcha", features = ["task", "http1"]}
 tokio = {version = "1", features = ["macros", 'rt-multi-thread']}
 serde = {version="1", features=["derive"]}

--- a/gotcha/Cargo.toml
+++ b/gotcha/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gotcha"
 description = "Enhanced web framework built on top of Axum with OpenAPI, metrics, and configuration management"
 edition = "2021"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 repository = "https://github.com/Kilerd/gotcha/"
 # Symlinked to the repository README so the crate documentation and the landing page are the same
@@ -35,8 +35,8 @@ task = ["dep:cron", "tokio/time"]
 
 [dependencies]
 async-trait = "0.1.60"
-gotcha_macro = { version = "0.3", path = "../gotcha_macro" }
-gotcha_core = { version = "0.3", path = "../gotcha_core", optional = true }
+gotcha_macro = { version = "0.4", path = "../gotcha_macro" }
+gotcha_core = { version = "0.4", path = "../gotcha_core", optional = true }
 serde = {version = "1", features = ["derive"]}
 # `rt` is needed by the message system, which is always available (it gated nothing but a
 # 160-line module and this one tokio feature).
@@ -76,7 +76,7 @@ trybuild = "1.0"
 assert-json-diff = "2"
 # Non-optional so trybuild-generated test crates (which derive Schematic and thus
 # emit `::gotcha_core::` paths) have gotcha_core in their extern prelude.
-gotcha_core = { version = "0.3", path = "../gotcha_core" }
+gotcha_core = { version = "0.4", path = "../gotcha_core" }
 # So `#[tokio::main]` doc examples compile (the lib's own tokio dep is minimal).
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 futures-core = "0.3.33"

--- a/gotcha/src/lib.rs
+++ b/gotcha/src/lib.rs
@@ -10,7 +10,7 @@
 
 pub use async_trait::async_trait;
 /// WebSocket upgrade and the socket itself. The frame type stays behind `ws::Message`, since
-/// [`Message`](crate::Message) is already the message-system trait.
+/// [`Message`] is already the message-system trait.
 pub use axum::extract::ws::{self, WebSocket, WebSocketUpgrade};
 use axum::extract::FromRef;
 pub use axum::extract::{Extension, Form, Json, Multipart, Path, Query, State};

--- a/gotcha_core/Cargo.toml
+++ b/gotcha_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gotcha_core"
 description = "Lightweight schema core (Schematic trait + data-type impls) for the Gotcha web framework"
 edition = "2021"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 repository = "https://github.com/Kilerd/gotcha/"
 
@@ -23,7 +23,7 @@ doctest = true
 axum = ["dep:axum", "dep:axum-extra", "dep:regex", "dep:either"]
 
 [dependencies]
-gotcha_macro = { version = "0.3", path = "../gotcha_macro" }
+gotcha_macro = { version = "0.4", path = "../gotcha_macro" }
 oas = "0.1"
 axum = { version = "0.8", default-features = false, features = ["json", "query", "multipart"], optional = true }
 # `TypedHeader<T>` lives here since axum 0.7; the impl must be in this crate because that is where

--- a/gotcha_macro/Cargo.toml
+++ b/gotcha_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gotcha_macro"
 description = "gotcha web framework macro"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Version bump for the 0.4.0 release: all three crates, the internal dependency ranges, the README, and the examples that pin a version.

## What 0.4 contains

Tiers 0, 1 and 2 of the maturation roadmap (#41) are complete.

**axum 0.8 (#73)**
- Route paths use `{id}` instead of `:id` — axum 0.8 rejects the old form at startup, so **every application must edit its routes**. It also removes work from gotcha: `{id}` is what OpenAPI already used, so the framework no longer translates between the two syntaxes.
- Newly re-exported, so they no longer need `gotcha::axum::…`: `Form`, `Multipart`, `Sse`/`Event`/`KeepAlive`, `WebSocketUpgrade`/`WebSocket`, `middleware`, `MatchedPath`, `OriginalUri`. (`Form` and `Multipart` were already supported internally — only the re-export was missing.)
- `GotchaRouter::fallback_service` handles unmatched requests with a `Service` rather than a handler.

**Documentation, made real (#71)**
- docs.rs now builds with **all features**. It previously built with defaults only (`http1`), so `#[api]`, `Schematic`, `Operable` and the entire OpenAPI layer were **invisible on docs.rs**.
- Feature-gated items carry a "requires feature X" badge.
- `#![deny(missing_docs)]`, and the 64 public items that needed documenting.
- The README **is** the crate documentation, so its examples are doctests and can't rot again (#28).

**Configuration, redesigned (#60)**
- The application's own settings live at the **top level** of the file; the framework's sit in a reserved `[server]` section.
- `#[config]` makes the application's config extractable as `State<Config>`; `State<ServerConfig>` covers the bind settings.
- mofa 0.2: environment overrides work for **typed** fields (`APP_SERVER__PORT=8080`), and `__` is the path separator so snake_case fields are addressable (#61, Kilerd/mofa#2).

**Feature flags, trimmed (#70)**
- `message` is gone — the message system is always available.
- `cors` / `static_files` were *broken*, not redundant: `tower-http` was declared with both sub-features, so wanting CORS also compiled the whole static-file stack. Each now enables only its own half.
- CI stopped testing the powerset: **127 jobs became 7**.

**Correctness / trust (Tier 0)**
- Config loading honours profiles and really fails on missing required files (#27)
- Cron tasks validate up front and survive panics instead of dying silently (#40)
- Schematic fixes: tuple/newtype variants, `DateTime` format, `Vec` requiredness, primitive names, `serde_json::Value` (#37, #18)
- serde compatibility: `skip` / `default` / `skip_serializing_if` (#38)
- `#[state]` makes `State<T>` extraction actually compile (#26)
- A usable `Messager` with application-state access (#29)
- Handlers returning nothing compile at all, and document an empty body rather than an invalid `type: "void"` (#62)

**Framework identity (Tier 1)**
- One router-assembly path shared by the `GotchaApp` trait and the `Gotcha` builder (#30)
- `GotchaError` + `GotchaResult` with `IntoResponse`, replacing panics/unwraps (#31)

**OpenAPI (Tier 2)**
- `components`/`$ref` instead of inlining — **recursive types now produce a finite spec** (#32)
- The error side of `Result<T, E>` is documented (#33)
- `.openapi(|spec| ..)` to customize Info / servers / security (#34)
- `#[schematic(...)]` documentation metadata (#35)
- `#[api(summary/deprecated/security)]` plus header/cookie parameters — `TypedHeader<T>`, `Header<T>`/`Cookie<T>`, `HeaderMap`, `Option<T>` (#36)

**Validation (Tier 3, landed early)**
- `Valid<Json<T>>` backed by the `validator` crate; rejects with `422` and readable messages
- `#[validate(..)]` drives both the runtime check **and** the schema keywords — written once (#9)

## Breaking changes since 0.3.0

Two require an edit in every application, and both are covered step by step in `MIGRATION.md`:

1. **Route paths**: `:id` → `{id}` (axum 0.8 rejects the old form)
2. **Config files**: application keys move out of `[application]` to the top level, `[basic]` → `[server]`; nested env overrides use `__`

Also:
- `features = ["message"]` should be dropped
- `Responsible for Result<T, E>` requires `E: ErrorResponsible` (blanket-implemented for `E: Schematic` and `(StatusCode, Json<E>)`)
- A hand-written `FromRequest`/`FromRequestParts` impl drops `#[async_trait]` (axum-core 0.5)
- `Operable` gained `summary` and `security` fields
- New default dependencies: `validator`, `axum-extra`; `mofa` 0.1 → 0.2

## Verification

Locally: every feature combination builds and tests, `gotcha_core` and `gotcha_macro` suites, doctests, `cargo clippy --all-features --workspace`, `cargo fmt --check`, and a nightly `--cfg docsrs` doc build with no warnings.

Publishing (`gotcha_macro` → `gotcha_core` → `gotcha`) and the `v0.4.0` tag happen after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)