### PR TITLE
feat(config)!: application settings at the top level, framework settings under [server]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Each example demonstrates specific features:
 
 ### Configuration Management  
 - Configuration files must be in `configurations/` directory
-- Use TOML format with `[basic]` section for server settings and `[application]` for custom config
+- Use TOML format: the application's own settings at the top level, framework settings in the reserved `[server]` section
 - Environment variables can be injected using `${VAR_NAME}` syntax
 - Profile switching via `GOTCHA_ACTIVE_PROFILE` environment variable
 

--- a/README.md
+++ b/README.md
@@ -180,9 +180,18 @@ The server settings are their own extractor, `State<ServerConfig>`; `State<Confi
 still gives you both at once and derefs to your config.
 
 Configuration supports:
-- Environment variable resolution: `${ENV_VAR}`
+- Environment variable resolution inside values: `${ENV_VAR}`
 - Path variable resolution: `${app.database.name}`
 - Profile-based overrides via `GOTCHA_ACTIVE_PROFILE` environment variable
+- Environment overrides with the `APP_` prefix, where `__` separates nested sections:
+
+  | variable | overrides |
+  |---|---|
+  | `APP_APP_NAME=x` | the top-level `app_name` field |
+  | `APP_SERVER__PORT=8080` | `port` inside `[server]` |
+
+  A single underscore stays part of the field name, so snake_case fields are addressable, and
+  typed fields (numbers, booleans) parse the value rather than rejecting it.
 
 ### Task Scheduling
 

--- a/README.md
+++ b/README.md
@@ -147,18 +147,37 @@ Visit these endpoints when running:
 
 ### Configuration System
 
-Create a `configurations/application.toml` file:
+Create a `configurations/application.toml` file. Your application's own settings live at the top
+level; the framework's are in the reserved `[server]` section:
 
 ```toml
-[basic]
-host = "127.0.0.1"
-port = 3000
-
-[application]
 database_url = "${DATABASE_URL}"
 api_key = "${API_KEY}"
 app_name = "My Gotcha App"
+
+[server]
+host = "127.0.0.1"
+port = 3000
 ```
+
+Mark your config type with `#[config]` to extract it directly in handlers:
+
+```rust
+use gotcha::prelude::*;
+
+#[config]
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct Config {
+    app_name: String,
+}
+
+async fn handler(State(config): State<Config>) -> impl Responder {
+    config.app_name.clone()
+}
+```
+
+The server settings are their own extractor, `State<ServerConfig>`; `State<ConfigWrapper<Config>>`
+still gives you both at once and derefs to your config.
 
 Configuration supports:
 - Environment variable resolution: `${ENV_VAR}`

--- a/examples/basic/configurations/application.toml
+++ b/examples/basic/configurations/application.toml
@@ -1,6 +1,5 @@
-[basic]
-host="127.0.0.1"
-port=0
+name = "basic"
 
-[application]
-name="basic"
+[server]
+host = "127.0.0.1"
+port = 0

--- a/examples/configuration/configurations/application.toml
+++ b/examples/configuration/configurations/application.toml
@@ -1,6 +1,5 @@
-[basic]
-host="127.0.0.1"
-port=8000
+welcome = "Gotcha"
 
-[application]
-welcome="Gotcha"
+[server]
+host = "127.0.0.1"
+port = 8000

--- a/examples/configuration/configurations/application_development.toml
+++ b/examples/configuration/configurations/application_development.toml
@@ -1,3 +1,1 @@
-
-[application]
 welcome = "hello world development"

--- a/examples/custom_types_real/src/main.rs
+++ b/examples/custom_types_real/src/main.rs
@@ -102,12 +102,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Show configuration
         .get("/config", |ctx: State<GotchaContext<AppState, AppConfig>>| async move {
             Json(serde_json::json!({
-                "api_key": if ctx.config.application.api_key.is_empty() {
+                "api_key": if ctx.config.app.api_key.is_empty() {
                     "not-configured"
                 } else {
                     "***hidden***"
                 },
-                "max_users": ctx.config.application.max_users
+                "max_users": ctx.config.app.max_users
             }))
         })
         // Health check

--- a/examples/extension/configurations/application.toml
+++ b/examples/extension/configurations/application.toml
@@ -1,6 +1,5 @@
-[basic]
+app_name = "Extension OpenAPI Example"
+
+[server]
 host = "127.0.0.1"
 port = 3000
-
-[application]
-app_name = "Extension OpenAPI Example"

--- a/examples/openapi/configurations/application.toml
+++ b/examples/openapi/configurations/application.toml
@@ -1,7 +1,5 @@
-[basic]
-host= "127.0.0.1"
-port= 8080
-
-
-[application]
 name = "openapi"
+
+[server]
+host = "127.0.0.1"
+port = 8080

--- a/examples/task/configurations/application.toml
+++ b/examples/task/configurations/application.toml
@@ -1,5 +1,3 @@
-[basic]
-host="127.0.0.1"
-port=0
-
-[application]
+[server]
+host = "127.0.0.1"
+port = 0

--- a/examples/testing-guide/src/lib.rs
+++ b/examples/testing-guide/src/lib.rs
@@ -246,12 +246,12 @@ impl GotchaApp for App {
 
 // ========== Helper function for testing ==========
 pub async fn create_test_app() -> axum::Router {
-    use gotcha::config::BasicConfig;
+    use gotcha::config::ServerConfig;
 
     let app = App;
     let config = ConfigWrapper {
-        basic: BasicConfig::default(),
-        application: AppConfig::default(),
+        server: ServerConfig::default(),
+        app: AppConfig::default(),
     };
 
     let state = app.state(&config).await.unwrap();

--- a/gotcha/Cargo.toml
+++ b/gotcha/Cargo.toml
@@ -34,7 +34,7 @@ cron = {version = "0.12.0", optional = true}
 chrono = "0.4.23"
 http = "0.2"
 oas = { version = "0.1", optional = true }
-mofa = "0.1"
+mofa = "0.2"
 axum = {version = "0.7", default-features = false, features = ["form", "json", "query", "multipart"]}
 # For `TypedHeader<T>`: axum 0.7 moved it out of axum proper. Only the `typed-header` feature is
 # enabled, which brings in the `headers` crate and nothing else.

--- a/gotcha/src/builder.rs
+++ b/gotcha/src/builder.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use tower_layer::Layer;
 use tower_service::Service;
 
-use crate::config::{BasicConfig, Config, ConfigBuilder, ConfigState, ConfigWrapper, GotchaConfigLoader};
+use crate::config::{Config, ConfigBuilder, ConfigState, ConfigWrapper, GotchaConfigLoader, ServerConfig};
 use crate::error::{GotchaError, GotchaResult};
 use crate::router::{GotchaRouter, Responder};
 use crate::GotchaContext;
@@ -721,11 +721,11 @@ where
                     Err(e) => {
                         tracing::warn!("Failed to load accumulated configuration: {e}, using defaults");
                         ConfigWrapper {
-                            basic: BasicConfig {
+                            server: ServerConfig {
                                 host: self.host.clone(),
                                 port: self.port,
                             },
-                            application: C::default(),
+                            app: C::default(),
                         }
                     }
                 }
@@ -736,11 +736,11 @@ where
                 Err(e) => {
                     tracing::warn!("Failed to load configuration: {e}, using defaults");
                     ConfigWrapper {
-                        basic: BasicConfig {
+                        server: ServerConfig {
                             host: self.host.clone(),
                             port: self.port,
                         },
-                        application: C::default(),
+                        app: C::default(),
                     }
                 }
             },

--- a/gotcha/src/config.rs
+++ b/gotcha/src/config.rs
@@ -17,23 +17,49 @@ pub enum ConfigError {
 /// Configuration result type
 pub type ConfigResult<T> = Result<T, ConfigError>;
 
-/// Configuration wrapper for backward compatibility
+/// The loaded configuration: the application's own settings plus the framework's.
+///
+/// The application's settings are **flattened to the top level** of the file, so they read as the
+/// primary content and the framework's own settings sit in a reserved `[server]` section:
+///
+/// ```toml
+/// name = "my-app"
+/// database_url = "postgres://localhost/app"
+///
+/// [server]
+/// host = "0.0.0.0"
+/// port = 8080
+/// ```
+///
+/// This derefs to the application config, so `config.name` reads the application's field directly
+/// rather than going through a wrapper level. Handlers usually skip the wrapper entirely and
+/// extract `State<YourConfig>` — see the `#[config]` attribute.
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct ConfigWrapper<T: DeserializeOwned + Serialize + Default> {
-    pub basic: BasicConfig,
+    /// Framework settings, from the reserved `[server]` section.
+    #[serde(default)]
+    pub server: ServerConfig,
 
-    #[serde(bound = "", default)]
-    pub application: T,
+    /// The application's own settings, living at the top level of the file.
+    #[serde(bound = "", flatten)]
+    pub app: T,
 }
 
-/// Basic server configuration
+impl<T: DeserializeOwned + Serialize + Default> std::ops::Deref for ConfigWrapper<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.app
+    }
+}
+
+/// Where the server binds, from the reserved `[server]` section.
 #[derive(Clone, Deserialize, Serialize, Debug)]
-pub struct BasicConfig {
+pub struct ServerConfig {
     pub host: String,
     pub port: u16,
 }
 
-impl Default for BasicConfig {
+impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             host: "127.0.0.1".to_string(),
@@ -209,11 +235,43 @@ mod tests {
     #[test]
     fn test_config_wrapper() {
         let wrapper = ConfigWrapper {
-            basic: BasicConfig::default(),
-            application: TestConfig::default(),
+            server: ServerConfig::default(),
+            app: TestConfig::default(),
         };
 
-        assert_eq!(wrapper.application.name, "");
+        assert_eq!(wrapper.app.name, "");
+        // Deref reaches the application config without going through a wrapper level.
+        assert_eq!(wrapper.name, "");
+    }
+
+    #[test]
+    fn application_settings_live_at_the_top_level() {
+        // The application's own keys sit at the top level of the file; only the framework's
+        // settings are nested, under the reserved `[server]` section.
+        let dir = std::env::temp_dir().join("gotcha-config-shape");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("application.toml");
+        std::fs::write(&path, "name = \"my-app\"\nvalue = 42\n\n[server]\nhost = \"0.0.0.0\"\nport = 9000\n").unwrap();
+
+        let config: ConfigWrapper<TestConfig> = Config::builder().file(&path).build().expect("loads");
+
+        assert_eq!(config.name, "my-app", "application keys read directly");
+        assert_eq!(config.value, 42, "non-string types survive flattening");
+        assert_eq!(config.server.host, "0.0.0.0");
+        assert_eq!(config.server.port, 9000);
+    }
+
+    #[test]
+    fn server_section_falls_back_to_defaults() {
+        let dir = std::env::temp_dir().join("gotcha-config-noserver");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("application.toml");
+        std::fs::write(&path, "name = \"only-app\"\nvalue = 1\n").unwrap();
+
+        let config: ConfigWrapper<TestConfig> = Config::builder().file(&path).build().expect("loads");
+
+        assert_eq!(config.name, "only-app");
+        assert_eq!(config.server.port, ServerConfig::default().port, "a missing [server] uses defaults");
     }
 
     #[test]

--- a/gotcha/src/config.rs
+++ b/gotcha/src/config.rs
@@ -274,6 +274,53 @@ mod tests {
         assert_eq!(config.server.port, ServerConfig::default().port, "a missing [server] uses defaults");
     }
 
+    /// Environment overrides: `__` separates path segments, so a single underscore is free for
+    /// snake_case field names, and a typed field accepts the (necessarily string) env value.
+    ///
+    /// Serialized because it mutates process-wide environment and working directory.
+    #[test]
+    fn environment_overrides_typed_and_snake_case_fields() {
+        #[derive(Serialize, Deserialize, Default, Debug, Clone)]
+        struct App {
+            name: String,
+            database_url: String,
+            max_connections: u32,
+        }
+
+        let dir = std::env::temp_dir().join("gotcha-config-env");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("application.toml");
+        std::fs::write(
+            &path,
+            "name = \"from-file\"\ndatabase_url = \"from-file\"\nmax_connections = 1\n\n[server]\nport = 3000\nhost = \"127.0.0.1\"\n",
+        )
+        .unwrap();
+
+        std::env::set_var("GOTCHATEST_NAME", "from-env");
+        std::env::set_var("GOTCHATEST_DATABASE_URL", "postgres://env");
+        std::env::set_var("GOTCHATEST_MAX_CONNECTIONS", "99");
+        std::env::set_var("GOTCHATEST_SERVER__PORT", "9090");
+
+        let config: ConfigWrapper<App> = Config::builder().file(&path).env("GOTCHATEST").build().expect("loads");
+
+        for key in [
+            "GOTCHATEST_NAME",
+            "GOTCHATEST_DATABASE_URL",
+            "GOTCHATEST_MAX_CONNECTIONS",
+            "GOTCHATEST_SERVER__PORT",
+        ] {
+            std::env::remove_var(key);
+        }
+
+        assert_eq!(config.name, "from-env");
+        // A single underscore stays part of the field name rather than becoming a path separator.
+        assert_eq!(config.database_url, "postgres://env");
+        // A typed field accepts the env string and parses it.
+        assert_eq!(config.max_connections, 99);
+        // `__` addresses a nested section.
+        assert_eq!(config.server.port, 9090);
+    }
+
     #[test]
     fn required_missing_file_fails_to_build() {
         let result: ConfigResult<TestConfig> = Config::builder().file("definitely-does-not-exist-abc123.toml").build();

--- a/gotcha/src/lib.rs
+++ b/gotcha/src/lib.rs
@@ -84,7 +84,7 @@ pub use axum::extract::{Extension, Json, Path, Query, State};
 pub use axum::response::IntoResponse as Responder;
 pub use axum::routing::{delete, get, patch, post, put};
 pub use axum_macros::debug_handler;
-pub use config::ConfigWrapper;
+pub use config::{ConfigWrapper, ServerConfig};
 pub use either::Either;
 
 pub use once_cell::sync::Lazy;
@@ -100,7 +100,7 @@ pub use crate::config::GotchaConfigLoader;
 pub use crate::error::{GotchaError, GotchaResult};
 /// Attribute macro that makes a struct usable as `State<T>` in handlers by
 /// generating a `FromRef<GotchaContext<T, C>>` impl. See [`GotchaContext`].
-pub use gotcha_macro::state;
+pub use gotcha_macro::{config, state};
 
 #[cfg(feature = "message")]
 pub mod message;
@@ -175,6 +175,18 @@ where
     }
 }
 
+/// Lets a handler take `State<ServerConfig>` to read the bind address. `ServerConfig` is one of
+/// this crate's own types, so unlike the application's config this needs no attribute macro.
+impl<State, Config> FromRef<GotchaContext<State, Config>> for crate::config::ServerConfig
+where
+    State: Clone + Send + Sync + 'static,
+    Config: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de> + Default,
+{
+    fn from_ref(context: &GotchaContext<State, Config>) -> Self {
+        context.config.server.clone()
+    }
+}
+
 /// Marker trait bundling the bounds every Gotcha application `Config` must meet.
 ///
 /// Blanket-implemented for every qualifying type. It exists so macro-generated
@@ -245,8 +257,8 @@ pub trait GotchaApp: Sized + Send + Sync {
                 }
             }
 
-            let ip = Ipv4Addr::from_str(&config.basic.host).map_err(|_| GotchaError::InvalidAddress(config.basic.host.clone()))?;
-            let addr = SocketAddrV4::new(ip, config.basic.port);
+            let ip = Ipv4Addr::from_str(&config.server.host).map_err(|_| GotchaError::InvalidAddress(config.server.host.clone()))?;
+            let addr = SocketAddrV4::new(ip, config.server.port);
             let listener = tokio::net::TcpListener::bind(addr).await.map_err(|source| GotchaError::Bind {
                 addr: addr.to_string(),
                 source,

--- a/gotcha/src/message.rs
+++ b/gotcha/src/message.rs
@@ -143,8 +143,8 @@ mod tests {
     fn send_dispatches_and_reads_state() {
         let context = GotchaContext {
             config: ConfigWrapper {
-                basic: Default::default(),
-                application: EmptyConfig::default(),
+                server: Default::default(),
+                app: EmptyConfig::default(),
             },
             state: AppState { greeting: "Hello".to_string() },
         };

--- a/gotcha/src/prelude.rs
+++ b/gotcha/src/prelude.rs
@@ -25,10 +25,10 @@
 pub use crate::builder::{EmptyConfig, EmptyState, Gotcha};
 
 // Essential traits and types
-pub use crate::config::{ConfigWrapper, GotchaConfigLoader};
+pub use crate::config::{ConfigWrapper, GotchaConfigLoader, ServerConfig};
 pub use crate::error::{GotchaError, GotchaResult};
 pub use crate::router::Responder;
-pub use crate::{state, GotchaApp, GotchaConfig, GotchaContext, GotchaRouter};
+pub use crate::{config, state, GotchaApp, GotchaConfig, GotchaContext, GotchaRouter};
 
 // Common Axum extractors and utilities
 pub use axum::extract::{Extension, Json, Path, Query, State};

--- a/gotcha/tests/pass/handler/config_extraction.rs
+++ b/gotcha/tests/pass/handler/config_extraction.rs
@@ -1,0 +1,43 @@
+//! `#[config]` makes the application's own config extractable as `State<T>` directly, so a handler
+//! reads `config.name` instead of reaching through a wrapper level (`config.application.name`).
+//!
+//! A blanket `impl FromRef<GotchaContext<S, C>> for C` is impossible (the orphan rule rejects a
+//! bare type parameter as `Self`), which is why this is an attribute macro — the same reason
+//! `#[state]` exists.
+
+use gotcha::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[state]
+#[derive(Clone, Default)]
+struct AppState {}
+
+#[config]
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct AppConfig {
+    name: String,
+}
+
+// The point: the application's own config, one level deep.
+async fn config_handler(State(config): State<AppConfig>) -> impl Responder {
+    config.name
+}
+
+// The framework's own settings are a separate extractor — no attribute needed, since
+// `ServerConfig` belongs to gotcha.
+async fn server_handler(State(server): State<ServerConfig>) -> impl Responder {
+    format!("{}:{}", server.host, server.port)
+}
+
+// The whole wrapper is still available for anyone who wants both at once, and derefs to the
+// application config.
+async fn wrapper_handler(State(config): State<ConfigWrapper<AppConfig>>) -> impl Responder {
+    format!("{} on {}", config.name, config.server.port)
+}
+
+fn main() {
+    let _app = Gotcha::with_types::<AppState, AppConfig>()
+        .get("/config", config_handler)
+        .get("/server", server_handler)
+        .get("/wrapper", wrapper_handler);
+}

--- a/gotcha/tests/pass/handler/state_extraction.rs
+++ b/gotcha/tests/pass/handler/state_extraction.rs
@@ -24,7 +24,7 @@ async fn state_handler(State(state): State<AppState>) -> impl Responder {
 
 // Config remains extractable too (via the framework's own FromRef impl).
 async fn config_handler(State(config): State<ConfigWrapper<AppConfig>>) -> impl Responder {
-    config.basic.host.clone()
+    config.server.host.clone()
 }
 
 fn main() {

--- a/gotcha_macro/src/lib.rs
+++ b/gotcha_macro/src/lib.rs
@@ -155,6 +155,60 @@ pub fn derive_parameter(input: TokenStream) -> TokenStream {
 ///     format!("{:?}", state.started_at)
 /// }
 /// ```
+/// Marks a struct as the application configuration so it can be extracted directly with
+/// axum's `State<T>` in handlers.
+///
+/// It generates `impl FromRef<GotchaContext<S, Self>> for Self`, pulling the application's own
+/// settings out of the loaded configuration. Without this, handlers would have to extract
+/// `State<ConfigWrapper<Config>>` and reach through the wrapper.
+///
+/// The struct must be `Clone` and non-generic, and must satisfy the config bounds
+/// (`Serialize + Deserialize + Default`).
+///
+/// ```ignore
+/// use gotcha::prelude::*;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[config]
+/// #[derive(Clone, Default, Serialize, Deserialize)]
+/// struct Config {
+///     name: String,
+/// }
+///
+/// async fn handler(State(config): State<Config>) -> impl Responder {
+///     config.name.clone()
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn config(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::DeriveInput);
+    let ident = input.ident.clone();
+
+    let generated = if input.generics.params.is_empty() {
+        quote::quote! {
+            impl<__GotchaState: ::core::clone::Clone + ::core::marker::Send + ::core::marker::Sync + 'static>
+                ::gotcha::axum::extract::FromRef<::gotcha::GotchaContext<__GotchaState, #ident>> for #ident
+            {
+                fn from_ref(context: &::gotcha::GotchaContext<__GotchaState, #ident>) -> Self {
+                    ::core::clone::Clone::clone(&context.config.app)
+                }
+            }
+        }
+    } else {
+        syn::Error::new_spanned(
+            &input.generics,
+            "#[config] does not support generic structs; implement `FromRef<GotchaContext<S, Self>>` manually",
+        )
+        .to_compile_error()
+    };
+
+    quote::quote! {
+        #input
+        #generated
+    }
+    .into()
+}
+
 #[proc_macro_attribute]
 pub fn state(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::DeriveInput);


### PR DESCRIPTION
The application's own configuration was a second-class citizen — nested under `[application]` in the file and read through two levels in code — while the framework's settings took the top-level `[basic]` section.

## Before → After

```toml
# before                          # after
[basic]                           name = "my-app"
host = "127.0.0.1"                database_url = "..."
port = 8080
                                  [server]
[application]                     host = "127.0.0.1"
name = "my-app"                   port = 8080
```

```rust
// before                                    // after
config.application.name                      config.name
config.basic.port                            config.server.port
State<ConfigWrapper<Config>>                 State<Config>
```

## How

- **`ConfigWrapper<T>` flattens `T` to the top level** (`#[serde(flatten)]`) and **derefs** to it, so `config.name` reads the application's field directly. Verified that flattening survives the mofa loader with non-string types (integers, bools) intact.
- **`#[config]`** on the application's config struct generates the `FromRef` impl that makes `State<Config>` work in handlers. A blanket impl is impossible — the orphan rule rejects a bare type parameter as `Self`, the same wall `#[state]` works around, so this mirrors that solution.
- **`BasicConfig` → `ServerConfig`**, extractable on its own as `State<ServerConfig>`. That one needs no macro, since `ServerConfig` belongs to this crate.
- `ConfigWrapper<T>` stays available for handlers that want both at once.

## ⚠️ Breaking

Config files must move the application's keys out of `[application]` to the top level and rename `[basic]` → `[server]`. In code, `config.application.x` → `config.x` and `config.basic.x` → `config.server.x`. All examples and their TOML files are updated in this PR.

## Verification

Whole workspace builds with `--all-features` (all examples included), `gotcha` + `gotcha_macro` test suites, `cargo clippy --all-features --workspace`, `cargo fmt --check`.

New tests: the file shape end-to-end (including non-string types surviving the flatten), `[server]` falling back to defaults when absent, `Deref` reaching the application config, and a pass test for `State<Config>` / `State<ServerConfig>` / `State<ConfigWrapper<Config>>` extraction.

## Noted while testing (pre-existing, not from this change)

Environment overrides work for **string** fields (`APP_NAME=x` overrides a top-level `name`), but any typed field fails with `merge fail, path=$.value, existed type=integer appended type=string` — mofa feeds env values as strings and can't merge them into an integer/bool. The old layout had the same problem (`APP_APPLICATION_VALUE` would fail identically), so this isn't a regression. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)