### PR TITLE
fix(openapi): unit-returning handlers compile and document an empty body (closes #62)

### DIFF
--- a/gotcha/tests/pass/openapi/unit_responses.rs
+++ b/gotcha/tests/pass/openapi/unit_responses.rs
@@ -1,0 +1,58 @@
+//! A handler that returns nothing documents a response with no content — and, more basically,
+//! compiles at all. `#[api]` on a handler with no return type used to fail with `E0782: expected a
+//! type, found a trait`, and `()` used to document as `{"type": "void"}`, which is not a valid
+//! OpenAPI type.
+//!
+//! The documented status is whatever axum actually sends, which is `200` with an empty body — not
+//! `204`. The test pins that against the real `IntoResponse` impl so the document cannot drift
+//! away from the runtime behaviour.
+
+use gotcha::axum::response::IntoResponse;
+use gotcha::{api, openapi::Operable, Json};
+
+// The case that did not compile before.
+#[api(id = "no_return")]
+async fn no_return() {}
+
+// The explicit spelling of the same thing.
+#[api(id = "explicit_unit")]
+async fn explicit_unit() -> () {}
+
+// Wrapping the unit in `Json` is genuinely different: that sends `null` with a 200.
+#[api(id = "json_unit")]
+async fn json_unit() -> Json<()> {
+    Json(())
+}
+
+fn extract<H, T>(_handler: H) -> &'static Operable
+where
+    H: gotcha::axum::handler::Handler<T, ()>,
+    T: 'static,
+{
+    gotcha::router::extract_operable::<H, T, ()>().expect("handler is registered")
+}
+
+fn main() {
+    // What axum actually sends for `()` — the documented status has to match this.
+    let actual_status = ().into_response().status();
+    assert_eq!(actual_status.as_u16(), 200, "axum sends 200 with an empty body for the unit type");
+
+    for operable in [extract(no_return), extract(explicit_unit)] {
+        let responses = operable.generate("/x".to_owned()).responses;
+        let rendered = serde_json::to_string(&responses).unwrap();
+
+        let documented = actual_status.as_u16().to_string();
+        assert!(responses.data.contains_key(&documented), "documents the status axum sends: {rendered}");
+
+        let gotcha::oas::Referenceable::Data(response) = &responses.data[&documented] else {
+            panic!("expected an inline response");
+        };
+        assert!(response.content.is_none(), "an empty body carries no content: {rendered}");
+    }
+
+    // `Json<()>` still documents a 200 body, and its schema is valid (no bogus `"void"` type).
+    let json_responses = extract(json_unit).generate("/j".to_owned()).responses;
+    let rendered = serde_json::to_string(&json_responses).unwrap();
+    assert!(json_responses.data.contains_key("200"), "Json<()> keeps its 200: {rendered}");
+    assert!(!rendered.contains("void"), "`void` is not a valid OpenAPI type: {rendered}");
+}

--- a/gotcha_core/src/lib.rs
+++ b/gotcha_core/src/lib.rs
@@ -65,6 +65,12 @@ pub trait Schematic {
     fn fields() -> Vec<(&'static str, EnhancedSchema)> {
         vec![]
     }
+    /// Whether a value of this type is sent as an empty body. Only the unit type is, and
+    /// [`Responsible`](crate::Responsible) documents it as a response with no content rather than
+    /// as a JSON body.
+    fn empty_body() -> bool {
+        false
+    }
     /// Generate the schema of the type.
     fn generate_schema() -> EnhancedSchema {
         EnhancedSchema {
@@ -117,6 +123,10 @@ impl_primitive_type! { bool, "bool", "boolean"}
 impl_primitive_type! { f32, "f32", "number"}
 impl_primitive_type! { f64, "f64", "number"}
 
+/// The unit type means "no value". As a *return* type that is an empty body, which
+/// [`Responsible`](crate::Responsible) documents as a response carrying no content. In the rare
+/// case it appears as a schema (`Json<()>`, which serializes as `null`) it produces an empty
+/// schema — `"void"` is not a valid OpenAPI type and made the generated document invalid.
 impl Schematic for () {
     fn name() -> &'static str {
         "void"
@@ -128,6 +138,23 @@ impl Schematic for () {
 
     fn type_() -> &'static str {
         "void"
+    }
+
+    fn empty_body() -> bool {
+        true
+    }
+
+    fn generate_schema() -> EnhancedSchema {
+        EnhancedSchema {
+            schema: Schema {
+                _type: None,
+                format: None,
+                nullable: None,
+                description: None,
+                extras: Default::default(),
+            },
+            required: false,
+        }
     }
 }
 

--- a/gotcha_core/src/responsible.rs
+++ b/gotcha_core/src/responsible.rs
@@ -44,7 +44,28 @@ fn json_response<T: Schematic>() -> Responses {
     response
 }
 
-// todo: add response for ()
+/// A response with no body.
+///
+/// axum sends `200` with an empty body for a handler that returns `()` — `impl IntoResponse for ()`
+/// defers to `Body::empty()`, and `http::Response::new` defaults to `StatusCode::OK`. It is *not*
+/// a `204`, so this documents `200` with no content to match what the server actually sends. A
+/// handler that wants `204` returns `StatusCode::NO_CONTENT` explicitly.
+fn empty_body_response() -> Responses {
+    let mut response = Responses {
+        default: None,
+        data: BTreeMap::default(),
+    };
+    response.data.insert(
+        "200".to_string(),
+        Referenceable::Data(Response {
+            description: "no content".to_string(),
+            headers: None,
+            content: None,
+            links: None,
+        }),
+    );
+    response
+}
 
 #[cfg(feature = "axum")]
 impl<T> Responsible for axum::Json<T>
@@ -61,7 +82,14 @@ where
     T: Schematic,
 {
     fn response() -> Responses {
-        json_response::<T>()
+        // A handler returning `()` sends an empty body, so it documents a `200` with no content.
+        // Wrapping the unit in `Json` is different — that really does send `null` — and goes
+        // through the `Json<T>` impl above instead.
+        if T::empty_body() {
+            empty_body_response()
+        } else {
+            json_response::<T>()
+        }
     }
 }
 

--- a/gotcha_macro/src/route.rs
+++ b/gotcha_macro/src/route.rs
@@ -93,9 +93,12 @@ pub(crate) fn request_handler(args: TokenStream, input_stream: TokenStream) -> T
         .collect();
     let ret_pos = &input.sig.output;
     let ret_schematic = match ret_pos {
+        // A handler with no return type returns `()`, which documents as `204 No Content`.
+        // This used to be `( () as ::gotcha::Responsible)` — a cast to a *trait*, which does not
+        // compile (E0782), so such a handler could not be annotated at all.
         ReturnType::Default => {
             quote! {
-                Box::new(|| { ( () as ::gotcha::Responsible).response() })
+                Box::new(|| { <() as ::gotcha::Responsible>::response() })
             }
         }
 


### PR DESCRIPTION
Closes #62. Two problems with handlers that return nothing.

## 1. `#[api]` on a handler with no return type didn't compile

```rust
#[api(id = "no_return")]
async fn no_return() {}     // error[E0782]: expected a type, found a trait
```

The `ReturnType::Default` branch generated `( () as ::gotcha::Responsible)` — a cast to a *trait*. So an ordinary "returns nothing" handler (a `DELETE`, say) could not be annotated at all. The existing `no-args-handler` test only covers no *arguments*; its handler returns `String`, so this path was never exercised.

Now emits `<() as Responsible>::response()`.

## 2. `()` documented as `"type": "void"` — not a valid OpenAPI type

```json
{"200":{"content":{"application/json":{"schema":{"type":"void"}}}}}
```

`void` isn't among the permitted values, so the document was invalid and client generators reject it. A new `Schematic::empty_body()` (default `false`, `true` for `()`) lets the blanket `Responsible` impl document the unit type as a response with **no content**.

### Which status? `200`, not `204`

Worth stating explicitly, since `204 No Content` is the intuitive guess. axum sends **`200` with an empty body**:

```rust
impl IntoResponse for () { Body::empty().into_response() }   // axum-core/src/response/into_response.rs:126
impl IntoResponse for Body { Response::new(self) }           // :167
```

`http::Response::new` defaults to `StatusCode::OK`, and there is no `NO_CONTENT` anywhere in axum-core's response module. Documenting `204` would have recreated exactly the doc-vs-reality mismatch this PR is fixing. A handler that wants `204` returns `StatusCode::NO_CONTENT` explicitly.

The test pins this down by asserting the documented status against `().into_response().status()` itself, so if axum ever changes, the test fails rather than the document silently lying.

## `Json<()>` is deliberately left alone

Wrapping the unit in `Json` is genuinely different: it really does send `null` with a `200`. That keeps its JSON response; only the schema changed, from the invalid `"void"` to an empty schema.

## Test

`tests/pass/openapi/unit_responses.rs` covers all three shapes — no return type, explicit `-> ()`, and `Json<()>` — asserting the response carries no content and that `"void"` appears nowhere.

Verified locally: `gotcha` (openapi) + `gotcha_core` suites, `cargo clippy --all-features --workspace`, `cargo fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)