### PR TITLE
docs: a rustdoc-based documentation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An enhanced web framework built on top of Axum, providing additional features an
 
 ### Simple Builder API (Recommended for new projects)
 
-```rust
+```rust,no_run
 use gotcha::prelude::*;
 
 #[tokio::main]
@@ -49,14 +49,20 @@ struct User {
 
 ### Advanced Trait API (For complex applications)
 
-```rust
-use gotcha::{ConfigWrapper, GotchaApp, GotchaContext, GotchaResult, GotchaRouter, State};
-use serde::{Deserialize, Serialize};
+```rust,no_run
+use gotcha::prelude::*;
 
+#[config]
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct Config {
     pub database_url: String,
     pub redis_url: String,
+}
+
+#[state]
+#[derive(Clone, Default)]
+pub struct AppState {
+    pub started_at: u64,
 }
 
 pub struct App {}
@@ -65,7 +71,7 @@ impl GotchaApp for App {
     type State = AppState;
     type Config = Config;
 
-    fn routes(&self, router: GotchaRouter<GotchaContext<Self::State, Self::Config>>) 
+    fn routes(&self, router: GotchaRouter<GotchaContext<Self::State, Self::Config>>)
         -> GotchaRouter<GotchaContext<Self::State, Self::Config>> {
         router
             .get("/", hello_world)
@@ -73,13 +79,19 @@ impl GotchaApp for App {
     }
 
     async fn state(&self, config: &ConfigWrapper<Self::Config>) -> GotchaResult<Self::State> {
-        // Initialize database connections, etc.
-        Ok(AppState::new(&config.database_url).await?)
+        // Open database connections here; `config` is already loaded.
+        let _ = &config.database_url;
+        Ok(AppState::default())
     }
 }
 
-async fn hello_world(_state: State<ConfigWrapper<Config>>) -> &'static str {
-    "Hello World"
+// The application's own config and state extract directly, thanks to `#[config]` / `#[state]`.
+async fn hello_world(State(config): State<Config>) -> impl Responder {
+    config.redis_url.clone()
+}
+
+async fn get_user(Path(id): Path<u32>, State(_state): State<AppState>) -> impl Responder {
+    format!("user {id}")
 }
 
 #[tokio::main]
@@ -122,8 +134,8 @@ Available features:
 
 With the `openapi` feature enabled, use the `#[api]` macro for automatic documentation:
 
-```rust
-use gotcha::{api, Json, Path, Schematic};
+```rust,ignore
+use gotcha::prelude::*;
 
 #[derive(Schematic, Serialize, Deserialize)]
 struct User {
@@ -135,7 +147,7 @@ struct User {
 /// Get user by ID
 #[api(id = "get_user", group = "users")]
 async fn get_user(Path(id): Path<u32>) -> Json<User> {
-    // Implementation here
+    Json(User { id, name: "Ada".into(), email: "ada@example.com".into() })
 }
 ```
 
@@ -194,12 +206,25 @@ Configuration supports:
 
 ### Task Scheduling
 
-```rust
-use gotcha::{GotchaApp, GotchaResult, TaskScheduler};
+Requires the `task` feature.
+
+```rust,ignore
+use gotcha::prelude::*;
 use std::time::Duration;
 
+# pub struct App {}
 impl GotchaApp for App {
-    // ... other implementations
+    type State = ();
+    type Config = EmptyConfig;
+
+    fn routes(&self, router: GotchaRouter<GotchaContext<Self::State, Self::Config>>)
+        -> GotchaRouter<GotchaContext<Self::State, Self::Config>> {
+        router
+    }
+
+    async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> GotchaResult<Self::State> {
+        Ok(())
+    }
 
     async fn tasks(&self, scheduler: &mut TaskScheduler<Self::State, Self::Config>) -> GotchaResult<()> {
         // Daily cleanup at 2 AM (cron fields: sec min hour day month weekday)
@@ -219,7 +244,7 @@ impl GotchaApp for App {
 
 Gotcha is organized as a Rust workspace with the following structure:
 
-```
+```text
 gotcha/
 ├── gotcha/           # Main framework crate
 ├── gotcha_macro/     # Procedural macros
@@ -299,7 +324,7 @@ cd examples/message && cargo run   # Message system
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/Kilerd/gotcha/blob/main/LICENSE) file for details.
 
 ## 🔗 Related Projects
 

--- a/gotcha/Cargo.toml
+++ b/gotcha/Cargo.toml
@@ -5,6 +5,16 @@ edition = "2021"
 version = "0.3.0"
 license = "MIT"
 repository = "https://github.com/Kilerd/gotcha/"
+# Symlinked to the repository README so the crate documentation and the landing page are the same
+# file. The symlink also makes `include_str!("../README.md")` resolve both in the workspace and in
+# the packaged crate, where cargo places the README at the package root.
+readme = "README.md"
+
+# docs.rs builds with every feature, so the OpenAPI layer and the rest of the optional surface
+# actually appear; `docsrs` turns on the per-item "requires feature X" badges.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 doctest = true

--- a/gotcha/README.md
+++ b/gotcha/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/gotcha/src/config.rs
+++ b/gotcha/src/config.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ConfigError {
     #[error("Configuration error: {0}")]
+    /// A configuration source could not be read, parsed, or merged.
     Error(String),
 }
 
@@ -55,7 +56,9 @@ impl<T: DeserializeOwned + Serialize + Default> std::ops::Deref for ConfigWrappe
 /// Where the server binds, from the reserved `[server]` section.
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct ServerConfig {
+    /// Address the server binds to.
     pub host: String,
+    /// Port the server listens on.
     pub port: u16,
 }
 
@@ -71,8 +74,11 @@ impl Default for ServerConfig {
 /// Simple configuration builder state
 #[derive(Clone, Debug, Default)]
 pub struct ConfigState {
+    /// Configuration files added to the builder, in the order they were added.
     pub file_paths: Vec<PathBuf>,
+    /// Environment variable prefixes the builder reads from.
     pub env_prefixes: Vec<String>,
+    /// Whether `${VAR}` substitution is enabled.
     pub enable_vars: bool,
 }
 

--- a/gotcha/src/error.rs
+++ b/gotcha/src/error.rs
@@ -21,7 +21,12 @@ pub enum GotchaError {
 
     /// The server failed to bind to the given address.
     #[error("failed to bind server to {addr}: {source}")]
-    Bind { addr: String, source: std::io::Error },
+    Bind {
+        /// The address the server tried to bind to.
+        addr: String,
+        /// Why the bind failed.
+        source: std::io::Error,
+    },
 
     /// An I/O error from the runtime (e.g. `axum::serve`).
     #[error(transparent)]

--- a/gotcha/src/lib.rs
+++ b/gotcha/src/lib.rs
@@ -1,86 +1,12 @@
-//! # Gotcha
-//!
-//! Gotcha is an enhanced web framework based on Axum, providing additional features and conveniences
-//! for building web applications in Rust.
-//!
-//! ## Features
-//!
-//! - Built on top of Axum for high performance and reliability
-//! - OpenAPI documentation generation (optional)
-//! - Prometheus metrics integration (optional)
-//! - CORS support and static file serving (optional)
-//! - Task scheduling (optional)
-//! - Configuration management
-//! - Request validation
-//! - Message system
-//! - State management
-//!
-//! ## Simple Example (New Builder API)
-//!
-//! ```no_run
-//! use gotcha::prelude::*;
-//!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     Gotcha::new()
-//!         .get("/", || async { "Hello World" })
-//!         .get("/hello/:name", |Path(name): Path<String>| async move {
-//!             format!("Hello, {}!", name)
-//!         })
-//!         .listen("127.0.0.1:3000")
-//!         .await?;
-//!     Ok(())
-//! }
-//! ```
-//!
-//! ## Advanced Example (Traditional Trait API)
-//!
-//! ```no_run
-//! use gotcha::{ConfigWrapper, GotchaApp, GotchaContext, GotchaResult, GotchaRouter, Responder, State};
-//! use serde::{Deserialize, Serialize};
-//!
-//! pub async fn hello_world(_state: State<ConfigWrapper<Config>>) -> impl Responder {
-//!     "hello world"
-//! }
-//!
-//! #[derive(Debug, Deserialize, Serialize, Clone, Default)]
-//! pub struct Config {
-//!     pub name: String,
-//! }
-//!
-//! pub struct App {}
-//!
-//! impl GotchaApp for App {
-//!     type State = ();
-//!     type Config = Config;
-//!
-//!     fn routes(&self, router: GotchaRouter<GotchaContext<Self::State, Self::Config>>) -> GotchaRouter<GotchaContext<Self::State, Self::Config>> {
-//!         router.get("/", hello_world)
-//!     }
-//!
-//!     async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> GotchaResult<Self::State> {
-//!         Ok(())
-//!     }
-//! }
-//!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     App {}.run().await?;
-//!     Ok(())
-//! }
-//! ```
-//!
-//! ## Optional Features
-//!
-//! Each one gates a dependency that not every application needs; everything else — configuration,
-//! the message system, validation, header/cookie parameters — is always available.
-//!
-//! - `openapi` - OpenAPI documentation generation (`oas`, `gotcha_core`)
-//! - `prometheus` - Prometheus metrics (`axum-prometheus`)
-//! - `cors` - CORS layer (`tower-http/cors`, which has no dependencies of its own)
-//! - `static_files` - Static file serving (`tower-http/fs`, which pulls in mime and range handling)
-//! - `task` - Background task scheduling (`cron`)
-//!
+// The crate documentation is the README, so the front page and the repository landing page cannot
+// drift apart — and its examples become doctests, so they cannot rot either.
+#![doc = include_str!("../README.md")]
+// Every public item carries documentation. This is denied rather than warned so an undocumented
+// item fails the build instead of quietly accumulating (64 had, before this was turned on).
+#![deny(missing_docs)]
+// `doc(cfg(..))` is nightly-only, so it is applied on docs.rs (which sets `--cfg docsrs`) and
+// skipped everywhere else. It puts a "requires feature X" badge on each gated item.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use async_trait::async_trait;
 use axum::extract::FromRef;
@@ -108,17 +34,22 @@ pub use gotcha_macro::{config, state};
 
 pub mod message;
 #[cfg(feature = "openapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "openapi")))]
 pub use gotcha_core::Responsible;
 
 #[cfg(feature = "openapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "openapi")))]
 pub use crate::openapi::schematic::{ParameterProvider, Schematic};
 #[cfg(feature = "openapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "openapi")))]
 pub use gotcha_macro::api;
 #[cfg(feature = "openapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "openapi")))]
 pub use oas;
 
 pub use crate::message::{Message, Messager};
 #[cfg(feature = "openapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "openapi")))]
 pub use crate::openapi::Operable;
 pub use crate::params::{Cookie, CookieParam, Header, HeaderParam, ParamRejection};
 pub use crate::validation::{Valid, ValidRejection};
@@ -133,37 +64,52 @@ pub mod builder;
 pub mod config;
 pub mod error;
 #[cfg(feature = "openapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "openapi")))]
 pub mod openapi;
 pub mod params;
 pub mod prelude;
+/// The router that tracks OpenAPI operations alongside axum routes.
 pub mod router;
 
 #[cfg(feature = "task")]
+#[cfg_attr(docsrs, doc(cfg(feature = "task")))]
 pub mod task;
 pub mod validation;
 
 #[cfg(feature = "prometheus")]
+#[cfg_attr(docsrs, doc(cfg(feature = "prometheus")))]
+/// Prometheus metrics, re-exported from `axum-prometheus`.
 pub mod prometheus {
     pub use axum_prometheus::metrics::*;
 }
 
+/// Middleware layers re-exported from `tower-http`.
 pub mod layers {
     #[cfg(feature = "cors")]
     pub use tower_http::cors::{self, CorsLayer};
 }
 
 #[cfg(feature = "openapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "openapi")))]
 pub use crate::openapi::schematic::EnhancedSchema;
 
 pub use serde_json;
 #[cfg(feature = "task")]
+#[cfg_attr(docsrs, doc(cfg(feature = "task")))]
 pub use task::TaskScheduler;
 #[cfg(feature = "static_files")]
+#[cfg_attr(docsrs, doc(cfg(feature = "static_files")))]
 pub use tower_http::services::{ServeDir, ServeFile};
 
 #[derive(Clone)]
+/// The axum state the framework injects: the loaded configuration plus the application state.
+///
+/// Handlers rarely name this directly — `#[state]` and `#[config]` make `State<AppState>` and
+/// `State<AppConfig>` extractable instead.
 pub struct GotchaContext<State: Clone + Send + Sync + 'static, Config: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de> + Default> {
+    /// The loaded configuration.
     pub config: ConfigWrapper<Config>,
+    /// The application state.
     pub state: State,
 }
 
@@ -197,10 +143,17 @@ where
 pub trait GotchaConfig: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de> + Default {}
 impl<T> GotchaConfig for T where T: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de> + Default {}
 
+/// The trait API: implement it to describe an application, then call `run()`.
+///
+/// The builder ([`Gotcha`]) is the simpler alternative; both assemble the router through the same
+/// path, so they behave identically.
 pub trait GotchaApp: Sized + Send + Sync {
+    /// The application state, shared by every handler.
     type State: Clone + Send + Sync + 'static;
+    /// The application's own configuration, read from the top level of the config file.
     type Config: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de> + Default;
 
+    /// Load the configuration. The default honours `GOTCHA_ACTIVE_PROFILE`.
     fn config(&self) -> impl std::future::Future<Output = GotchaResult<ConfigWrapper<Self::Config>>> + Send {
         async move {
             let config = GotchaConfigLoader::load::<ConfigWrapper<Self::Config>>(std::env::var("GOTCHA_ACTIVE_PROFILE").ok())?;
@@ -208,6 +161,7 @@ pub trait GotchaApp: Sized + Send + Sync {
         }
     }
 
+    /// Install the tracing subscriber. The default reads `RUST_LOG`.
     fn logger(&self) -> GotchaResult<()> {
         tracing_subscriber::registry()
             .with(fmt::layer())
@@ -222,15 +176,19 @@ pub trait GotchaApp: Sized + Send + Sync {
         Ok(())
     }
 
+    /// Register the application's routes.
     fn routes(&self, router: GotchaRouter<GotchaContext<Self::State, Self::Config>>) -> GotchaRouter<GotchaContext<Self::State, Self::Config>>;
 
+    /// Build the application state, given the loaded configuration.
     fn state(&self, config: &ConfigWrapper<Self::Config>) -> impl std::future::Future<Output = GotchaResult<Self::State>> + Send;
 
     #[cfg(feature = "task")]
+    /// Register background tasks. The default registers none.
     fn tasks(&self, _task_scheduler: &mut TaskScheduler<Self::State, Self::Config>) -> impl std::future::Future<Output = GotchaResult<()>> + Send {
         async { Ok(()) }
     }
 
+    /// Assemble the final axum router. Override only to wrap the whole application.
     fn build_router(&self, context: GotchaContext<Self::State, Self::Config>) -> impl std::future::Future<Output = GotchaResult<axum::Router>> + Send {
         async move {
             let router = GotchaRouter::<GotchaContext<Self::State, Self::Config>>::default();
@@ -239,6 +197,7 @@ pub trait GotchaApp: Sized + Send + Sync {
         }
     }
 
+    /// Load configuration, build state and routes, then serve until shutdown.
     fn run(self) -> impl std::future::Future<Output = GotchaResult<()>> + Send {
         async move {
             use std::net::{Ipv4Addr, SocketAddrV4};

--- a/gotcha/src/openapi/mod.rs
+++ b/gotcha/src/openapi/mod.rs
@@ -57,29 +57,43 @@ pub(crate) async fn scalar_html() -> impl Responder {
     Html(include_str!("../../statics/scalar.html"))
 }
 
+/// What one handler argument contributes: either operation parameters or the request body.
 pub type ParamType = Either<Vec<Parameter>, RequestBody>;
 
+/// Builds an argument's [`ParamType`] given the route path (needed to name path parameters).
 pub type ParamConstructor = Box<dyn Fn(String) -> ParamType + Sync + Send + 'static>;
 
+/// Rewrites axum's `:name` path segments into OpenAPI's `{name}` form.
 pub fn replace_path_variable(path: String) -> String {
     let regex = Regex::new(PATH_VARIABLE_PATTERN).unwrap();
     regex.replace_all(&path, |caps: &regex::Captures| format!("{{{}}}", &caps[0][1..])).to_string()
 }
 
 #[derive()]
+/// Everything the `#[api]` macro records about one handler, collected via `inventory`.
 pub struct Operable {
+    /// Fully qualified name of the handler function, used to match a route to its `Operable`.
     pub type_name: &'static str,
+    /// The operation id.
     pub id: &'static str,
+    /// Tag the operation is grouped under.
     pub group: Option<&'static str>,
+    /// Explicit summary; when absent it is derived from the id in Title Case.
     pub summary: Option<&'static str>,
+    /// Description, taken from the handler's doc comment.
     pub description: Option<&'static str>,
+    /// Whether the operation is marked deprecated.
     pub deprecated: bool,
+    /// Name of a security scheme this operation requires.
     pub security: Option<&'static str>,
+    /// One constructor per handler argument.
     pub parameters: &'static Lazy<Vec<ParamConstructor>>,
+    /// Builds the operation's responses from the handler's return type.
     pub responses: &'static Lazy<Box<dyn Fn() -> Responses + Sync + Send + 'static>>,
 }
 
 impl Operable {
+    /// Build the OpenAPI operation for this handler at `path`.
     pub fn generate(&self, path: String) -> Operation {
         let tags = self.group.map(|group| vec![group.to_string()]);
         let mut params = vec![];

--- a/gotcha/src/params.rs
+++ b/gotcha/src/params.rs
@@ -92,11 +92,28 @@ impl<T> std::ops::Deref for Cookie<T> {
 #[derive(Debug)]
 pub enum ParamRejection {
     /// A required parameter was absent.
-    Missing { kind: &'static str, name: &'static str },
+    Missing {
+        /// `"header"` or `"cookie"`.
+        kind: &'static str,
+        /// The parameter name.
+        name: &'static str,
+    },
     /// The parameter was present but could not be parsed.
-    Invalid { kind: &'static str, name: &'static str, message: String },
+    Invalid {
+        /// `"header"` or `"cookie"`.
+        kind: &'static str,
+        /// The parameter name.
+        name: &'static str,
+        /// Why the value was rejected.
+        message: String,
+    },
     /// The header value was not valid UTF-8, so it cannot be parsed as text.
-    NotText { kind: &'static str, name: &'static str },
+    NotText {
+        /// `"header"` or `"cookie"`.
+        kind: &'static str,
+        /// The parameter name.
+        name: &'static str,
+    },
 }
 
 impl IntoResponse for ParamRejection {

--- a/gotcha/src/prelude.rs
+++ b/gotcha/src/prelude.rs
@@ -44,6 +44,7 @@ pub use serde_json::{json, Value as JsonValue};
 pub use crate::async_trait;
 
 // Common result type
+/// A `Result` whose error defaults to a boxed `std::error::Error`, for `main` and quick handlers.
 pub type Result<T, E = Box<dyn std::error::Error + Send + Sync>> = std::result::Result<T, E>;
 
 // Feature-specific exports
@@ -58,6 +59,7 @@ pub use crate::TaskScheduler;
 
 // Utility macros for common patterns
 #[macro_export]
+/// Defines an async handler function with less ceremony.
 macro_rules! handler {
     // Simple async closure handler
     ($body:expr) => {
@@ -71,6 +73,7 @@ macro_rules! handler {
 }
 
 #[macro_export]
+/// Builds a `Json` response from a `serde_json::json!` literal.
 macro_rules! json_response {
     ($data:expr) => {
         axum::Json(serde_json::json!($data))
@@ -78,6 +81,7 @@ macro_rules! json_response {
 }
 
 #[macro_export]
+/// Starts a server on the given address with the given routes, for examples and prototypes.
 macro_rules! quick_server {
     (
         $(($method:ident, $path:literal, $handler:expr)),* $(,)?

--- a/gotcha/src/router.rs
+++ b/gotcha/src/router.rs
@@ -17,8 +17,10 @@ use crate::Operable;
 #[cfg(feature = "openapi")]
 use std::collections::HashMap;
 
+/// Generates the per-HTTP-method shorthand (`get`, `post`, …) on the router.
 macro_rules! implement_method {
     ($method:expr, $fn_name: tt ) => {
+        #[doc = concat!("Route `", stringify!($fn_name), "` requests for `path` to `handler`.")]
         pub fn $fn_name<H: Handler<T, State>, T: 'static>(self, path: &str, handler: H) -> Self {
             self.method_route(path, $method, handler)
         }
@@ -211,6 +213,7 @@ impl<State: Clone + Send + Sync + 'static> GotchaRouter<State> {
         }
     }
 
+    /// Handle requests that match no route.
     pub fn fallback<H, T>(self, handler: H) -> Self
     where
         H: Handler<T, State>,

--- a/gotcha/src/task.rs
+++ b/gotcha/src/task.rs
@@ -49,6 +49,8 @@ use tracing::info;
 
 use crate::GotchaContext;
 
+/// Registers background tasks that run alongside the server, each with access to the application
+/// context.
 pub struct TaskScheduler<T1: Clone + Send + Sync + 'static, T2: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de> + Default> {
     context: GotchaContext<T1, T2>,
 }
@@ -58,6 +60,7 @@ where
     T1: Clone + Send + Sync + 'static,
     T2: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de> + Default,
 {
+    /// Create a scheduler bound to the application context tasks will receive.
     pub fn new(context: GotchaContext<T1, T2>) -> Self {
         Self { context }
     }
@@ -83,6 +86,7 @@ where
         tokio::spawn(cron_proc_macro_wrapper(self.context.clone(), schedule, name, task));
     }
 
+    /// Run `task` every `interval`, starting one interval from now.
     pub fn interval<F, FF>(&self, name: impl AsRef<str>, interval: std::time::Duration, task: F)
     where
         F: Fn(GotchaContext<T1, T2>) -> FF + Send + 'static,
@@ -105,6 +109,7 @@ where
     }
 }
 
+/// Drives a cron task; called by the scheduler, not directly.
 pub async fn cron_proc_macro_wrapper<T1, T2, F, FF>(context: GotchaContext<T1, T2>, schedule: Schedule, name: String, task: F)
 where
     T1: Clone + Send + Sync + 'static,
@@ -122,6 +127,7 @@ where
     }
 }
 
+/// Drives an interval task; called by the scheduler, not directly.
 pub async fn interval_proc_macro_wrapper<T1, T2, F, FF>(context: GotchaContext<T1, T2>, interval: std::time::Duration, name: String, task: F)
 where
     T1: Clone + Send + Sync + 'static,

--- a/gotcha_core/Cargo.toml
+++ b/gotcha_core/Cargo.toml
@@ -6,6 +6,12 @@ version = "0.3.0"
 license = "MIT"
 repository = "https://github.com/Kilerd/gotcha/"
 
+# docs.rs builds with every feature, so the OpenAPI layer and the rest of the optional surface
+# actually appear; `docsrs` turns on the per-item "requires feature X" badges.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lib]
 doctest = true
 

--- a/gotcha_core/src/lib.rs
+++ b/gotcha_core/src/lib.rs
@@ -1,3 +1,8 @@
+// Every public item carries documentation, enforced rather than merely encouraged.
+#![deny(missing_docs)]
+// `doc(cfg(..))` is nightly-only; docs.rs sets `--cfg docsrs`, so the "requires feature X" badges
+// appear there and are skipped elsewhere.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! # Gotcha Core
 //!
 //! Lightweight schema core for the [Gotcha](https://github.com/Kilerd/gotcha/) web framework.
@@ -32,12 +37,17 @@ pub mod responsible;
 pub use responsible::Responsible;
 
 #[cfg(feature = "axum")]
+#[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 pub mod parameter;
 #[cfg(feature = "axum")]
+#[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 pub use parameter::ParameterProvider;
 
+/// A schema plus whether the value it describes is required where it appears.
 pub struct EnhancedSchema {
+    /// The OpenAPI schema itself.
     pub schema: Schema,
+    /// Whether the value must be present.
     pub required: bool,
 }
 
@@ -62,6 +72,7 @@ pub trait Schematic {
         None
     }
 
+    /// The type's fields, used to build object schemas and to flatten query parameters.
     fn fields() -> Vec<(&'static str, EnhancedSchema)> {
         vec![]
     }

--- a/gotcha_core/src/parameter.rs
+++ b/gotcha_core/src/parameter.rs
@@ -16,6 +16,7 @@ use crate::Schematic;
 
 /// ParameterProvider is a trait that defines the value which can be used as a parameter.
 pub trait ParameterProvider {
+    /// What this extractor contributes to the operation, given the route path.
     fn generate(_url: String) -> Either<Vec<Parameter>, RequestBody> {
         Either::Left(vec![])
     }

--- a/gotcha_core/src/responsible.rs
+++ b/gotcha_core/src/responsible.rs
@@ -13,7 +13,9 @@ use oas::{MediaType, Referenceable, Response, Responses};
 
 use crate::Schematic;
 
+/// Maps a handler's return type to the operation's OpenAPI responses.
 pub trait Responsible {
+    /// The responses this return type produces.
     fn response() -> Responses;
 }
 
@@ -100,6 +102,7 @@ where
 /// `E: Schematic` and for axum's `(StatusCode, Json<E>)` idiom; custom error types can implement
 /// it directly.
 pub trait ErrorResponsible {
+    /// Add this error type's responses to the operation's existing ones.
     fn error_responses(responses: &mut Responses);
 }
 

--- a/gotcha_macro/Cargo.toml
+++ b/gotcha_macro/Cargo.toml
@@ -5,6 +5,12 @@ version = "0.3.0"
 edition = "2021"
 license = "MIT"
 
+# docs.rs builds with every feature, so the OpenAPI layer and the rest of the optional surface
+# actually appear; `docsrs` turns on the per-item "requires feature X" badges.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lib]
 proc-macro = true
 


### PR DESCRIPTION
Four changes that together make the generated documentation the real one.

## 1. docs.rs was showing half the framework

There was no `[package.metadata.docs.rs]`, so docs.rs builds with **default features only** — which is just `http1`. That means `#[api]`, `Schematic`, `Operable`, `ParameterProvider` and the entire OpenAPI layer **never appeared on docs.rs at all**: the framework's headline capability was invisible to anyone reading the published docs.

All three crates now declare:

```toml
[package.metadata.docs.rs]
all-features = true
rustdoc-args = ["--cfg", "docsrs"]
```

## 2. Feature-gated items say which feature they need

Building with all features would otherwise imply everything is unconditionally available. `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` puts a "requires feature X" badge on each gated item. Nightly-only, so it applies on docs.rs and is skipped elsewhere.

## 3. `#![deny(missing_docs)]` — and the 64 items that needed it

Every public item across `gotcha` and `gotcha_core` is now documented: struct fields, trait methods, the macro-generated router methods (`get`/`post`/…), the `Operable` descriptor, the task scheduler. **Denied** rather than warned, so an undocumented public item fails the build instead of quietly accumulating — which is exactly how it reached 64.

## 4. The README is the crate documentation

`#![doc = include_str!("../README.md")]`, so the crate front page and the repository landing page cannot drift apart — and the README's examples become **doctests**. The README had already rotted once (#28); now it can't.

Three of its five examples compile and are tested. The two that need an optional feature (`#[api]` needs `openapi`, `TaskScheduler` needs `task`) are marked `ignore`, because an included README cannot be feature-gated and the matrix runs combinations where those features are off.

The flagship examples were also fixed rather than merely annotated — the Advanced Trait API example referenced an undefined `AppState` and `get_user`, so nobody copying it could have compiled it. It now defines both, and demonstrates `#[config]` / `#[state]` extraction.

## Two traps worth recording

**`include_str!` pointing outside the crate directory breaks the published crate.** Caught with `cargo publish --dry-run`:

```
error: couldn't read `src/../../README.md`: No such file or directory
```

Cargo packages the README at the *package root*, so the workspace path and the packaged path differ. `gotcha/README.md` is now a symlink to the repository README, which makes `include_str!("../README.md")` resolve correctly in both.

**A bare ``` fence is compiled as Rust by rustdoc.** The architecture diagram failed 28 parse errors until it was marked `text`.

## Verification

- Doctests: **34 passed**, 0 failed
- Every feature combination builds and tests (none / `openapi` / all)
- `cargo clippy --all-features --workspace`, `cargo fmt --check`
- Nightly `RUSTDOCFLAGS="--cfg docsrs" cargo doc --all-features` with **no warnings** (the `LICENSE` relative link was made absolute, since rustdoc can't resolve it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)