### PR TITLE
docs: a 0.3 → 0.4 migration guide, and make the configuration example demonstrate configuration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,97 @@
-# Migration Guide: API Simplification
+# Migration Guide
 
-This guide helps you migrate from the traditional trait-based API to the new simplified builder API introduced in Gotcha v0.3.0.
+- [0.3 → 0.4](#03--04) — **every application must edit its configuration file**
+- [0.2 → 0.3: API simplification](#02--03-api-simplification)
+
+---
+
+# 0.3 → 0.4
+
+The configuration file layout changed, so **this release cannot be adopted without editing your configuration**. Everything else is a smaller adjustment.
+
+## 1. Configuration files: application settings move to the top level
+
+The framework's own settings now live in a reserved `[server]` section, and your application's settings are the top level of the file — they used to be nested under `[application]` while `[basic]` took the top spot.
+
+```toml
+# before (0.3)                    # after (0.4)
+[basic]                           name = "my-app"
+host = "127.0.0.1"                database_url = "postgres://localhost/app"
+port = 8080
+                                  [server]
+[application]                     host = "127.0.0.1"
+name = "my-app"                   port = 8080
+database_url = "postgres://..."
+```
+
+Both profile files (`application.toml` and `application_{profile}.toml`) need the same treatment.
+
+## 2. Reading configuration in code
+
+```rust,ignore
+// before                         // after
+config.application.name           config.name
+config.basic.port                 config.server.port
+```
+
+`ConfigWrapper<T>` now dereferences to your own config type, which is what makes `config.name` work.
+
+Handlers can skip the wrapper entirely. Annotate your config type with `#[config]` and extract it directly:
+
+```rust,ignore
+#[config]
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct Config {
+    name: String,
+}
+
+async fn handler(State(config): State<Config>) -> impl Responder {
+    config.name.clone()
+}
+```
+
+The bind settings are their own extractor, `State<ServerConfig>`. `State<ConfigWrapper<Config>>` still works if you want both at once.
+
+## 3. Environment overrides use `__` between sections
+
+Nested paths are separated by a **double** underscore, which leaves single underscores free for snake_case field names:
+
+```console
+# before (never actually worked for typed fields — it failed the whole load)
+APP_SERVER_PORT=8080
+
+# after
+APP_SERVER__PORT=8080     # -> [server] port
+APP_DATABASE_URL=...      # -> the top-level `database_url` field
+```
+
+Typed fields (numbers, booleans) are now parsed from the environment string instead of failing to merge.
+
+## 4. The `message` feature is gone
+
+The message system is always available. Drop it from your feature list:
+
+```toml
+# before
+gotcha = { version = "0.3", features = ["openapi", "message"] }
+# after
+gotcha = { version = "0.4", features = ["openapi"] }
+```
+
+`cors` and `static_files` keep their names, but each now enables only its own half of `tower-http` — a CORS-only application no longer compiles the static-file stack.
+
+## 5. Smaller changes
+
+- **Validation rejections return `422`**, not `400`. `400` is still used for a malformed body. Every error now carries a readable `message`.
+- **`Result<T, E>` handlers** need `E: ErrorResponsible`. This is implemented for any `E: Schematic` and for axum's `(StatusCode, Json<E>)` idiom, so most code needs no change.
+- **Handlers returning nothing** now compile (they previously failed with `E0782`) and document an empty body.
+- **`Operable`** gained `summary` and `security` fields; only relevant if you construct it by hand rather than through `#[api]`.
+
+---
+
+# 0.2 → 0.3: API simplification
+
+This section helps you migrate from the traditional trait-based API to the simplified builder API introduced in Gotcha v0.3.0. Note that the configuration examples below use the 0.3 layout — see the 0.4 section above for the current one.
 
 ## TL;DR
 

--- a/examples/configuration/src/main.rs
+++ b/examples/configuration/src/main.rs
@@ -1,14 +1,56 @@
+//! Demonstrates the configuration system: the application's own settings live at the top level of
+//! `configurations/application.toml`, the framework's bind settings in the reserved `[server]`
+//! section, and the server listens on whatever that section says.
+//!
+//! Try it:
+//!
+//! ```console
+//! cargo run                                    # listens on the configured port (8000)
+//! APP_SERVER__PORT=9000 cargo run              # `__` addresses a nested section
+//! APP_WELCOME=hi cargo run                     # a single underscore stays part of the field name
+//! GOTCHA_ACTIVE_PROFILE=development cargo run  # also loads application_development.toml
+//! ```
+
 use gotcha::prelude::*;
+
+/// The application's own configuration — the top level of the file.
+#[config]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct Config {
+    welcome: String,
+}
+
+/// The application's config extracts directly, thanks to `#[config]`.
+async fn greet(State(config): State<Config>) -> impl Responder {
+    config.welcome.clone()
+}
+
+/// The framework's own settings are a separate extractor, and need no attribute.
+async fn where_am_i(State(server): State<ServerConfig>) -> impl Responder {
+    format!("listening on {}:{}", server.host, server.port)
+}
+
+struct App;
+
+impl GotchaApp for App {
+    type State = ();
+    type Config = Config;
+
+    fn routes(&self, router: GotchaRouter<GotchaContext<Self::State, Self::Config>>) -> GotchaRouter<GotchaContext<Self::State, Self::Config>> {
+        router.get("/", greet).get("/server", where_am_i)
+    }
+
+    async fn state(&self, config: &ConfigWrapper<Self::Config>) -> GotchaResult<Self::State> {
+        // `ConfigWrapper` derefs to the application config, so `config.welcome` reads the
+        // application's own field without going through a wrapper level.
+        gotcha::tracing::info!("loaded welcome message: {}", config.welcome);
+        Ok(())
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
-
-    let app = Gotcha::new()
-        .with_env_config("APP")
-        .with_optional_config("config.toml")
-        .get("/", || async { "Configuration example working!" });
-
-    app.listen("127.0.0.1:3000").await?;
+    // `run()` reads `configurations/application.toml` and binds the address from `[server]`.
+    App.run().await?;
     Ok(())
 }

--- a/gotcha/src/router.rs
+++ b/gotcha/src/router.rs
@@ -105,18 +105,26 @@ impl<State: Clone + Send + Sync + 'static> GotchaRouter<State> {
         #[cfg(feature = "openapi")]
         if let Some(operable) = handle_operable {
             tracing::info!("generating openapi spec for {}[{}]", &operable.type_name, &path);
-            let method = match method {
-                MethodFilter::DELETE => Method::DELETE,
-                MethodFilter::GET => Method::GET,
-                MethodFilter::HEAD => Method::HEAD,
-                MethodFilter::OPTIONS => Method::OPTIONS,
-                MethodFilter::PATCH => Method::PATCH,
-                MethodFilter::POST => Method::POST,
-                MethodFilter::PUT => Method::PUT,
-                MethodFilter::TRACE => Method::TRACE,
-                _ => todo!(),
+            let documented_method = match method {
+                MethodFilter::DELETE => Some(Method::DELETE),
+                MethodFilter::GET => Some(Method::GET),
+                MethodFilter::HEAD => Some(Method::HEAD),
+                MethodFilter::OPTIONS => Some(Method::OPTIONS),
+                MethodFilter::PATCH => Some(Method::PATCH),
+                MethodFilter::POST => Some(Method::POST),
+                MethodFilter::PUT => Some(Method::PUT),
+                MethodFilter::TRACE => Some(Method::TRACE),
+                // `MethodFilter` is `#[non_exhaustive]`. A method axum adds later should leave the
+                // route working and merely undocumented, rather than bringing the application down
+                // while it registers its routes (this used to be a `todo!()`).
+                _ => None,
             };
-            self.operations.insert((path.to_string(), method), operable);
+            match documented_method {
+                Some(method) => {
+                    self.operations.insert((path.to_string(), method), operable);
+                }
+                None => tracing::warn!("unrecognised method filter for {path}; the route works but is left out of the OpenAPI spec"),
+            }
         }
 
         let router = MethodRouter::new().on(method, handler);


### PR DESCRIPTION
Three gaps found while reviewing whether 0.4 was ready to publish.

## 1. `MIGRATION.md` was stale — and had become wrong

It documented only 0.2 → 0.3, and line 177 still showed:

```rust
DatabasePool::connect(&config.application.database_url).await
```

which **no longer compiles** in 0.4. Meanwhile 0.4 carries the most invasive breaking change the project has had — *every application must edit its configuration file* — and the repository offered no guide for it at all. The release notes covered it; the file a user actually opens when upgrading did not.

Adds a **0.3 → 0.4** section:

- configuration file layout (`[basic]`/`[application]` → top level + `[server]`), with a before/after
- reading config in code (`config.application.name` → `config.name`), and `#[config]` / `State<ServerConfig>`
- the `__` environment separator, and that typed fields now parse instead of failing the load
- the removed `message` feature, and that `cors` / `static_files` now enable only their own half of `tower-http`
- smaller changes: `422` validation rejections, `E: ErrorResponsible`, unit-returning handlers, `Operable` fields

The 0.2 → 0.3 section is kept and labelled — its examples are correct for the version it describes, and it now says so.

## 2. The configuration example did not demonstrate configuration

```rust
.with_optional_config("config.toml")   // does not exist — and optional, so it failed silently
.listen("127.0.0.1:3000")              // hardcoded, ignoring the `[server] port = 8000` it ships
```

The one example named after the feature was the one not showing it. It now uses the trait API, extracts the application config with `#[config]` and the bind settings with `State<ServerConfig>`, and lets `run()` bind what the file says.

**Verified by actually running it** rather than only compiling:

```console
$ curl :8000/          → Gotcha                         # top-level `welcome`
$ curl :8000/server    → listening on 127.0.0.1:8000    # the [server] section

$ APP_SERVER__PORT=9100 APP_WELCOME=from-env cargo run
$ curl :9100/          → from-env                       # single underscore = field name
$ curl :9100/server    → listening on 127.0.0.1:9100    # `__` = nested section
```

That also confirms end-to-end that the documented environment-override rules match real behaviour.

## 3. A `todo!()` in a production path

`gotcha/src/router.rs` matched `MethodFilter` with `_ => todo!()`. `MethodFilter` is `#[non_exhaustive]`, so a method axum adds later would **panic the application while it registered its routes**. It now leaves such a route working and merely undocumented, with a warning — consistent with the panic removal in #40 and #31.

## Verification

Workspace builds with `--all-features`, all feature combinations test, `clippy --all-features --workspace`, `fmt`, and the configuration example exercised over HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)