### PR TITLE
feat!: axum 0.8, plus the extractors and router methods it was hiding

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,15 +1,29 @@
 # Migration Guide
 
-- [0.3 → 0.4](#03--04) — **every application must edit its configuration file**
+- [0.3 → 0.4](#03--04) — **every application must edit its route paths and configuration file**
 - [0.2 → 0.3: API simplification](#02--03-api-simplification)
 
 ---
 
 # 0.3 → 0.4
 
-The configuration file layout changed, so **this release cannot be adopted without editing your configuration**. Everything else is a smaller adjustment.
+Two changes require edits in every application: **route paths** and the **configuration file**. Everything else is a smaller adjustment.
 
-## 1. Configuration files: application settings move to the top level
+## 1. Route paths use `{name}`, not `:name`
+
+Gotcha now builds on axum 0.8, which changed how a captured path segment is written — and rejects the old form outright rather than silently treating it as a literal:
+
+```rust,ignore
+// before                                  // after
+router.get("/users/:id", get_user)         router.get("/users/{id}", get_user)
+router.get("/f/*rest", serve)              router.get("/f/{*rest}", serve)
+```
+
+A path that still starts a segment with `:` fails at startup with *"Path segments must not start with `:`. For capture groups, use `{capture}`"*.
+
+This is the syntax OpenAPI already used, so gotcha no longer translates between the two — a route is documented exactly as it is registered.
+
+## 2. Configuration files: application settings move to the top level
 
 The framework's own settings now live in a reserved `[server]` section, and your application's settings are the top level of the file — they used to be nested under `[application]` while `[basic]` took the top spot.
 
@@ -26,7 +40,7 @@ database_url = "postgres://..."
 
 Both profile files (`application.toml` and `application_{profile}.toml`) need the same treatment.
 
-## 2. Reading configuration in code
+## 3. Reading configuration in code
 
 ```rust,ignore
 // before                         // after
@@ -52,7 +66,7 @@ async fn handler(State(config): State<Config>) -> impl Responder {
 
 The bind settings are their own extractor, `State<ServerConfig>`. `State<ConfigWrapper<Config>>` still works if you want both at once.
 
-## 3. Environment overrides use `__` between sections
+## 4. Environment overrides use `__` between sections
 
 Nested paths are separated by a **double** underscore, which leaves single underscores free for snake_case field names:
 
@@ -67,7 +81,7 @@ APP_DATABASE_URL=...      # -> the top-level `database_url` field
 
 Typed fields (numbers, booleans) are now parsed from the environment string instead of failing to merge.
 
-## 4. The `message` feature is gone
+## 5. The `message` feature is gone
 
 The message system is always available. Drop it from your feature list:
 
@@ -80,12 +94,14 @@ gotcha = { version = "0.4", features = ["openapi"] }
 
 `cors` and `static_files` keep their names, but each now enables only its own half of `tower-http` — a CORS-only application no longer compiles the static-file stack.
 
-## 5. Smaller changes
+## 6. Smaller changes
 
 - **Validation rejections return `422`**, not `400`. `400` is still used for a malformed body. Every error now carries a readable `message`.
 - **`Result<T, E>` handlers** need `E: ErrorResponsible`. This is implemented for any `E: Schematic` and for axum's `(StatusCode, Json<E>)` idiom, so most code needs no change.
 - **Handlers returning nothing** now compile (they previously failed with `E0782`) and document an empty body.
 - **`Operable`** gained `summary` and `security` fields; only relevant if you construct it by hand rather than through `#[api]`.
+- **axum 0.8** also removed `#[async_trait]` from its extractor traits. A hand-written `FromRequest` / `FromRequestParts` impl should drop the attribute and use a plain `async fn`.
+- **New re-exports**, so these no longer need `gotcha::axum::…`: `Form`, `Multipart`, `Sse` / `Event` / `KeepAlive`, `WebSocketUpgrade` / `WebSocket`, `middleware`, `MatchedPath`, `OriginalUri`. `GotchaRouter` also gained `fallback_service`.
 
 ---
 
@@ -201,7 +217,7 @@ impl GotchaApp for App {
     fn routes(&self, router: GotchaRouter<GotchaContext<Self::State, Self::Config>>) 
         -> GotchaRouter<GotchaContext<Self::State, Self::Config>> {
         router
-            .get("/users/:id", get_user)
+            .get("/users/{id}", get_user)
             .post("/users", create_user)
     }
 
@@ -231,7 +247,7 @@ pub struct User {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Gotcha::new()
-        .get("/users/:id", |Path(id): Path<u32>| async move {
+        .get("/users/{id}", |Path(id): Path<u32>| async move {
             Json(User { id, name: format!("User {}", id) })
         })
         .post("/users", |Json(user): Json<User>| async move {
@@ -406,7 +422,7 @@ impl GotchaApp for App {
 })
 
 // Structured responses
-.get("/user/:id", |Path(id): Path<u32>| async move {
+.get("/user/{id}", |Path(id): Path<u32>| async move {
     let user = User { id, name: "John" };
     Json(user)
 })

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An enhanced web framework built on top of Axum, providing additional features an
 - 📚 **Automatic OpenAPI** - Generate documentation from your code
 - 📊 **Prometheus Metrics** - Built-in metrics collection
 - 🌐 **CORS Support** - Cross-origin resource sharing
+- 🔌 **WebSocket & SSE** - Real-time endpoints, re-exported and ready
 - 📁 **Static Files** - Serve static content effortlessly
 - ⏰ **Task Scheduling** - Cron and interval-based background tasks
 - 💌 **Message System** - Built-in inter-service communication
@@ -29,7 +30,7 @@ use gotcha::prelude::*;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Gotcha::new()
         .get("/", || async { "Hello World" })
-        .get("/hello/:name", |Path(name): Path<String>| async move {
+        .get("/hello/{name}", |Path(name): Path<String>| async move {
             format!("Hello, {}!", name)
         })
         .post("/users", |Json(user): Json<User>| async move {
@@ -75,7 +76,7 @@ impl GotchaApp for App {
         -> GotchaRouter<GotchaContext<Self::State, Self::Config>> {
         router
             .get("/", hello_world)
-            .get("/users/:id", get_user)
+            .get("/users/{id}", get_user)
     }
 
     async fn state(&self, config: &ConfigWrapper<Self::Config>) -> GotchaResult<Self::State> {

--- a/examples/custom_types_real/src/main.rs
+++ b/examples/custom_types_real/src/main.rs
@@ -86,13 +86,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Json(users_vec)
         })
         // Get user by ID
-        .get("/users/:id", |Path(id): Path<u64>, ctx: State<GotchaContext<AppState, AppConfig>>| async move {
-            let users = ctx.state.users.read().await;
-            match users.get(&id) {
-                Some(user) => Ok(Json(user.clone())),
-                None => Err((StatusCode::NOT_FOUND, "User not found")),
-            }
-        })
+        .get(
+            "/users/{id}",
+            |Path(id): Path<u64>, ctx: State<GotchaContext<AppState, AppConfig>>| async move {
+                let users = ctx.state.users.read().await;
+                match users.get(&id) {
+                    Some(user) => Ok(Json(user.clone())),
+                    None => Err((StatusCode::NOT_FOUND, "User not found")),
+                }
+            },
+        )
         // Create new user
         .post("/users", || async {
             Json(serde_json::json!({

--- a/examples/extension/Cargo.toml
+++ b/examples/extension/Cargo.toml
@@ -11,4 +11,4 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
-axum = "0.7"
+axum = "0.8"

--- a/examples/openapi/src/main.rs
+++ b/examples/openapi/src/main.rs
@@ -99,13 +99,13 @@ impl GotchaApp for App {
         router
             .get("/", hello_world)
             .post("/pets", new_pet)
-            .get("/pets/:pet_id", get_pet)
-            .put("/pets/:pet_id", update_pet_info)
-            .put("/pets/:pet_id/address/:address_id", update_pet_address_detail)
+            .get("/pets/{pet_id}", get_pet)
+            .put("/pets/{pet_id}", update_pet_info)
+            .put("/pets/{pet_id}/address/{address_id}", update_pet_address_detail)
             // Test skip functionality
-            .post("/test/skip-json/:key_id", test_skip::test_skip_json)
-            .post("/test/skip-query/:key_id", test_skip::test_skip_query)
-            .post("/test/no-skip/:key_id", test_skip::test_no_skip)
+            .post("/test/skip-json/{key_id}", test_skip::test_skip_json)
+            .post("/test/skip-query/{key_id}", test_skip::test_skip_query)
+            .post("/test/no-skip/{key_id}", test_skip::test_no_skip)
     }
 
     async fn state(&self, _config: &ConfigWrapper<Self::Config>) -> Result<Self::State, gotcha::GotchaError> {

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -64,11 +64,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }))
         })
         // Path parameter example
-        .get("/hello/:name", |Path(name): Path<String>| async move {
+        .get("/hello/{name}", |Path(name): Path<String>| async move {
             format!("👋 Hello, {}! Welcome to Gotcha!", name)
         })
         // JSON response with path parameter
-        .get("/users/:id", |Path(id): Path<u32>| async move {
+        .get("/users/{id}", |Path(id): Path<u32>| async move {
             // In a real application, you would fetch this from a database
             let user = User {
                 id,

--- a/examples/testing-guide/Cargo.toml
+++ b/examples/testing-guide/Cargo.toml
@@ -11,11 +11,11 @@ gotcha_core = { path = "../../gotcha_core" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-axum = "0.7"
+axum = "0.8"
 uuid = { version = "1", features = ["serde", "v4"] }
+axum-test = "17"
 
 [dev-dependencies]
-axum-test = "16"
 tower = "0.5"
 http = "1"
 assert-json-diff = "2"

--- a/examples/testing-guide/src/lib.rs
+++ b/examples/testing-guide/src/lib.rs
@@ -237,10 +237,10 @@ impl GotchaApp for App {
         router
             .get("/health", health_check)
             .get("/users", list_users)
-            .get("/users/:id", get_user)
+            .get("/users/{id}", get_user)
             .post("/users", create_user)
-            .put("/users/:id", update_user)
-            .delete("/users/:id", delete_user)
+            .put("/users/{id}", update_user)
+            .delete("/users/{id}", delete_user)
     }
 }
 

--- a/gotcha/Cargo.toml
+++ b/gotcha/Cargo.toml
@@ -46,21 +46,20 @@ tracing-subscriber = {version="0.3", features=["env-filter"]}
 log = "0.4"
 cron = {version = "0.12.0", optional = true}
 chrono = "0.4.23"
-http = "0.2"
 oas = { version = "0.1", optional = true }
 mofa = "0.2"
-axum = {version = "0.7", default-features = false, features = ["form", "json", "query", "multipart"]}
+axum = { version = "0.8", default-features = false, features = ["form", "json", "query", "multipart", "ws", "matched-path", "original-uri"] }
 # For `TypedHeader<T>`: axum 0.7 moved it out of axum proper. Only the `typed-header` feature is
 # enabled, which brings in the `headers` crate and nothing else.
-axum-extra = { version = "0.9", default-features = false, features = ["typed-header"] }
+axum-extra = { version = "0.10", default-features = false, features = ["typed-header"] }
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
 inventory = "0.3.15"
 either = "1.13.0"
 convert_case = "0.6.0"
 once_cell = "1"
-axum-prometheus = { version = "0.7.0", optional = true }
-axum-macros = "0.4"
+axum-prometheus = { version = "0.8", optional = true }
+axum-macros = "0.5"
 # No features here — the `cors` / `static_files` flags each turn on the one they need.
 tower-http = { version = "0.6", optional = true, default-features = false }
 cfg-if = { workspace = true }
@@ -80,3 +79,6 @@ assert-json-diff = "2"
 gotcha_core = { version = "0.3", path = "../gotcha_core" }
 # So `#[tokio::main]` doc examples compile (the lib's own tokio dep is minimal).
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+futures-core = "0.3.33"
+futures-util = "0.3.33"
+tower = "0.5.3"

--- a/gotcha/src/builder.rs
+++ b/gotcha/src/builder.rs
@@ -428,7 +428,7 @@ where
     ///
     /// let app = Gotcha::new()
     ///     .get("/", || async { "Hello World" })
-    ///     .get("/users/:id", get_user);
+    ///     .get("/users/{id}", get_user);
     ///
     /// async fn get_user() -> impl Responder {
     ///     "User info"
@@ -559,8 +559,8 @@ where
     /// Add a layer to the application
     pub fn layer<L>(mut self, layer: L) -> Self
     where
-        L: Layer<axum::routing::Route> + Clone + Send + 'static,
-        L::Service: Service<Request> + Clone + Send + 'static,
+        L: Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request>>::Response: Responder + 'static,
         <L::Service as Service<Request>>::Error: Into<std::convert::Infallible> + 'static,
         <L::Service as Service<Request>>::Future: Send + 'static,

--- a/gotcha/src/lib.rs
+++ b/gotcha/src/lib.rs
@@ -9,8 +9,18 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use async_trait::async_trait;
+/// WebSocket upgrade and the socket itself. The frame type stays behind `ws::Message`, since
+/// [`Message`](crate::Message) is already the message-system trait.
+pub use axum::extract::ws::{self, WebSocket, WebSocketUpgrade};
 use axum::extract::FromRef;
-pub use axum::extract::{Extension, Json, Path, Query, State};
+pub use axum::extract::{Extension, Form, Json, Multipart, Path, Query, State};
+/// The request path as matched by the router (`/users/{id}`) and the URI before any nesting
+/// rewrote it. Both need axum features that this crate turns on.
+pub use axum::extract::{MatchedPath, OriginalUri};
+/// Writing custom middleware — `middleware::from_fn` and friends.
+pub use axum::middleware;
+/// Server-sent events.
+pub use axum::response::sse::{self, Event, KeepAlive, Sse};
 pub use axum::response::IntoResponse as Responder;
 pub use axum::routing::{delete, get, patch, post, put};
 pub use axum_macros::debug_handler;

--- a/gotcha/src/openapi/mod.rs
+++ b/gotcha/src/openapi/mod.rs
@@ -23,7 +23,7 @@
 //! }
 //!
 //! fn routes(router: GotchaRouter) -> GotchaRouter {
-//!     router.get("/users/:id", get_user)
+//!     router.get("/users/{id}", get_user)
 //! }
 //! ```
 //!
@@ -44,10 +44,13 @@ use crate::Responder;
 
 pub mod schematic;
 
-// Match `:name` path parameters up to the next `/`, mirroring axum (and
-// `ParameterProvider`). The previous `[a-z_]`-only pattern skipped `:userId`,
-// `:id2`, `:ID`, leaving them un-templated in the OpenAPI paths.
-static PATH_VARIABLE_PATTERN: &str = r":[^/]+";
+/// Match a `{name}` path parameter.
+///
+/// Since axum 0.8 routes are written the way OpenAPI writes them — `/users/{id}` — so this no
+/// longer rewrites anything. It stays as the single place that knows the syntax: [`crate::openapi`]
+/// uses it to normalise a path, and `ParameterProvider` uses the same shape to pull out parameter
+/// names. Before 0.8 axum used `:id`, and every path had to be translated here.
+pub(crate) static PATH_VARIABLE_PATTERN: &str = r"\{([^}]+)\}";
 
 pub(crate) async fn openapi_html() -> impl Responder {
     Html(include_str!("../../statics/redoc.html"))
@@ -63,10 +66,20 @@ pub type ParamType = Either<Vec<Parameter>, RequestBody>;
 /// Builds an argument's [`ParamType`] given the route path (needed to name path parameters).
 pub type ParamConstructor = Box<dyn Fn(String) -> ParamType + Sync + Send + 'static>;
 
-/// Rewrites axum's `:name` path segments into OpenAPI's `{name}` form.
+/// Normalise a route path into the form OpenAPI uses for path templating.
+///
+/// Since axum 0.8 the two agree — a route is registered as `/users/{id}` and documented as
+/// `/users/{id}` — so this is the identity. It is kept because the framework still owns the
+/// question "what does a documented path look like", and because axum 0.7 needed a real
+/// translation here (`:id` -> `{id}`).
 pub fn replace_path_variable(path: String) -> String {
-    let regex = Regex::new(PATH_VARIABLE_PATTERN).unwrap();
-    regex.replace_all(&path, |caps: &regex::Captures| format!("{{{}}}", &caps[0][1..])).to_string()
+    path
+}
+
+/// The parameter names a route path captures, in order: `/users/{id}/books/{isbn}` -> `id`, `isbn`.
+pub fn path_variable_names(path: &str) -> Vec<String> {
+    let regex = Regex::new(PATH_VARIABLE_PATTERN).expect("path variable pattern is valid");
+    regex.captures_iter(path).map(|caps| caps[1].to_string()).collect()
 }
 
 #[derive()]
@@ -228,12 +241,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_path_variable_pattern() {
-        assert_eq!(replace_path_variable("/users".to_string()), "/users");
-        assert_eq!(replace_path_variable("/users/:id".to_string()), "/users/{id}");
-        assert_eq!(replace_path_variable("/users/:id/:name".to_string()), "/users/{id}/{name}");
-        // camelCase, digits and uppercase are now templated too (previously skipped)
-        assert_eq!(replace_path_variable("/users/:userId".to_string()), "/users/{userId}");
-        assert_eq!(replace_path_variable("/items/:id2/:ID".to_string()), "/items/{id2}/{ID}");
+    fn documented_paths_match_the_registered_route() {
+        // axum 0.8 and OpenAPI write path parameters the same way, so a route is documented
+        // exactly as it was registered.
+        for path in ["/users", "/users/{id}", "/users/{id}/{name}", "/users/{userId}", "/items/{id2}/{ID}"] {
+            assert_eq!(replace_path_variable(path.to_string()), path);
+        }
+    }
+
+    #[test]
+    fn path_variables_are_extracted_in_order() {
+        assert_eq!(path_variable_names("/users/{id}/books/{isbn}"), ["id", "isbn"]);
+        // Names are not restricted to lowercase.
+        assert_eq!(path_variable_names("/items/{id2}/{ID}"), ["id2", "ID"]);
+        assert!(path_variable_names("/users").is_empty());
     }
 }

--- a/gotcha/src/params.rs
+++ b/gotcha/src/params.rs
@@ -24,7 +24,6 @@
 //! }
 //! ```
 
-use async_trait::async_trait;
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
@@ -139,7 +138,6 @@ fn resolve<T>(
     }
 }
 
-#[async_trait]
 impl<S, T> FromRequestParts<S> for Header<T>
 where
     T: HeaderParam,
@@ -157,7 +155,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, T> FromRequestParts<S> for Cookie<T>
 where
     T: CookieParam,

--- a/gotcha/src/prelude.rs
+++ b/gotcha/src/prelude.rs
@@ -31,8 +31,12 @@ pub use crate::router::Responder;
 pub use crate::{config, state, GotchaApp, GotchaConfig, GotchaContext, GotchaRouter};
 
 // Common Axum extractors and utilities
-pub use axum::extract::{Extension, Json, Path, Query, State};
+pub use axum::extract::ws::{WebSocket, WebSocketUpgrade};
+pub use axum::extract::{Extension, Form, Json, Multipart, Path, Query, State};
+pub use axum::extract::{MatchedPath, OriginalUri};
 pub use axum::http::{HeaderMap, Method, StatusCode};
+pub use axum::middleware;
+pub use axum::response::sse::{Event, KeepAlive, Sse};
 pub use axum::response::{Html, Redirect, Response};
 pub use axum::routing::{delete, get, patch, post, put};
 

--- a/gotcha/src/router.rs
+++ b/gotcha/src/router.rs
@@ -206,8 +206,8 @@ impl<State: Clone + Send + Sync + 'static> GotchaRouter<State> {
     /// ```
     pub fn layer<L>(self, layer: L) -> Self
     where
-        L: Layer<Route> + Clone + Send + 'static,
-        L::Service: Service<Request> + Clone + Send + 'static,
+        L: Layer<Route> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request>>::Response: Responder + 'static,
         <L::Service as Service<Request>>::Error: Into<Infallible> + 'static,
         <L::Service as Service<Request>>::Future: Send + 'static,
@@ -233,6 +233,37 @@ impl<State: Clone + Send + Sync + 'static> GotchaRouter<State> {
             #[cfg(feature = "openapi")]
             openapi_transform: self.openapi_transform,
             router: self.router.fallback(handler),
+        }
+    }
+
+    /// Handle unmatched requests with a `Service` rather than a handler.
+    ///
+    /// Useful for delegating to something that is already a tower service — serving a
+    /// single-page application's `index.html` with `ServeFile`, say, or forwarding to a
+    /// proxy — where [`fallback`](Self::fallback) would need a wrapper handler.
+    ///
+    /// ```rust,ignore
+    /// use gotcha::GotchaRouter;
+    /// use gotcha::axum::{body::Body, extract::Request, response::Response};
+    ///
+    /// let router: GotchaRouter<()> = GotchaRouter::default()
+    ///     .fallback_service(tower::service_fn(|_: Request| async {
+    ///         Ok::<_, std::convert::Infallible>(Response::new(Body::from("not found")))
+    ///     }));
+    /// ```
+    pub fn fallback_service<Svc, ResBody>(self, service: Svc) -> Self
+    where
+        Svc: Service<Request, Response = axum::http::Response<ResBody>, Error = Infallible> + Clone + Send + Sync + 'static,
+        Svc::Future: Send + 'static,
+        ResBody: axum::body::HttpBody<Data = axum::body::Bytes> + Send + 'static,
+        ResBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        Self {
+            #[cfg(feature = "openapi")]
+            operations: self.operations,
+            #[cfg(feature = "openapi")]
+            openapi_transform: self.openapi_transform,
+            router: self.router.fallback_service(service),
         }
     }
 

--- a/gotcha/src/validation.rs
+++ b/gotcha/src/validation.rs
@@ -39,7 +39,6 @@
 
 use std::borrow::Cow;
 
-use async_trait::async_trait;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{FromRequest, Request};
 use axum::http::StatusCode;
@@ -168,7 +167,6 @@ fn render_param(value: &serde_json::Value) -> String {
     }
 }
 
-#[async_trait]
 impl<S, T> FromRequest<S> for Valid<Json<T>>
 where
     T: DeserializeOwned + Validate,

--- a/gotcha/tests/builder_api.rs
+++ b/gotcha/tests/builder_api.rs
@@ -7,7 +7,7 @@ use gotcha::prelude::*;
 async fn test_builder_api_compiles() {
     let _gotcha = Gotcha::new()
         .get("/", || async { "Hello World" })
-        .get("/hello/:name", |Path(name): Path<String>| async move { format!("Hello, {}!", name) })
+        .get("/hello/{name}", |Path(name): Path<String>| async move { format!("Hello, {}!", name) })
         .post("/echo", |body: String| async move { format!("Echo: {}", body) })
         .routes(|router| router.get("/nested/ping", || async { "pong" }));
 

--- a/gotcha/tests/builder_api_test.rs
+++ b/gotcha/tests/builder_api_test.rs
@@ -48,6 +48,6 @@ fn test_chaining_works() {
         .port(8080)
         .get("/", || async { "home" })
         .post("/users", || async { "create user" })
-        .put("/users/:id", || async { "update user" })
-        .delete("/users/:id", || async { "delete user" });
+        .put("/users/{id}", || async { "update user" })
+        .delete("/users/{id}", || async { "delete user" });
 }

--- a/gotcha/tests/pass/handler/axum_surface.rs
+++ b/gotcha/tests/pass/handler/axum_surface.rs
@@ -1,0 +1,73 @@
+//! The axum capabilities gotcha re-exports: `Form`, `Multipart`, SSE, WebSocket, custom
+//! middleware, and `fallback_service`. These all existed in axum but had to be reached through
+//! `gotcha::axum::…` (or, for websockets and SSE, needed a feature this crate did not enable).
+
+use std::convert::Infallible;
+
+use gotcha::prelude::*;
+
+#[state]
+#[derive(Clone, Default)]
+struct AppState {}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct AppConfig {}
+
+#[derive(Deserialize)]
+struct Login {
+    user: String,
+}
+
+// A urlencoded body.
+async fn sign_in(Form(login): Form<Login>) -> impl Responder {
+    login.user
+}
+
+// A multipart upload.
+async fn upload(mut parts: Multipart) -> impl Responder {
+    let mut names = Vec::new();
+    while let Ok(Some(field)) = parts.next_field().await {
+        names.push(field.name().unwrap_or_default().to_string());
+    }
+    names.join(",")
+}
+
+// Server-sent events.
+async fn events() -> Sse<impl futures_core::Stream<Item = Result<Event, Infallible>>> {
+    let stream = futures_util::stream::once(async { Ok(Event::default().data("tick")) });
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+// A websocket upgrade.
+async fn socket(upgrade: WebSocketUpgrade) -> impl Responder {
+    upgrade.on_upgrade(|mut socket: WebSocket| async move {
+        // Echo one frame, then drop the socket.
+        if let Some(Ok(frame)) = socket.recv().await {
+            let _ = socket.send(frame).await;
+        }
+    })
+}
+
+// The route as the router matched it, and the URI before nesting rewrote it.
+async fn introspect(matched: MatchedPath, OriginalUri(uri): OriginalUri) -> impl Responder {
+    format!("{} {}", matched.as_str(), uri)
+}
+
+fn main() {
+    let _app = Gotcha::with_types::<AppState, AppConfig>()
+        .post("/sign-in", sign_in)
+        .post("/upload", upload)
+        .get("/events", events)
+        .get("/socket", socket)
+        .get("/introspect/{id}", introspect)
+        // Custom middleware, without reaching into `gotcha::axum`.
+        .layer(middleware::from_fn(|req: gotcha::axum::extract::Request, next: middleware::Next| async move {
+            next.run(req).await
+        }))
+        .routes(|router| {
+            // Unmatched requests can go to a `Service`, not just a handler.
+            router.fallback_service(tower::service_fn(|_: gotcha::axum::extract::Request| async {
+                Ok::<_, Infallible>(gotcha::axum::response::Response::new(gotcha::axum::body::Body::from("not found")))
+            }))
+        });
+}

--- a/gotcha/tests/pass/openapi/components_ref.rs
+++ b/gotcha/tests/pass/openapi/components_ref.rs
@@ -58,7 +58,7 @@ fn main() {
 
     let mut operables = std::collections::HashMap::new();
     operables.insert(("/tree".to_string(), Method::GET), operable(get_tree));
-    operables.insert(("/users/:id".to_string(), Method::GET), operable(get_user));
+    operables.insert(("/users/{id}".to_string(), Method::GET), operable(get_user));
     operables.insert(("/users".to_string(), Method::GET), operable(list_users));
     operables.insert(("/eval".to_string(), Method::GET), operable(eval_expr));
 

--- a/gotcha/tests/pass/openapi/handler_with_args.rs
+++ b/gotcha/tests/pass/openapi/handler_with_args.rs
@@ -55,7 +55,7 @@ where
 }
 fn main() {
     let operable = extract(path_tuple).unwrap();
-    let operation = operable.generate("/pets/:pet_id".to_string());
+    let operation = operable.generate("/pets/{pet_id}".to_string());
     assert!(operation.operation_id == Some("path_tuple".to_string()));
     assert!(operation.description == None);
     assert!(operation.deprecated == Some(false));
@@ -63,12 +63,12 @@ fn main() {
 
 
     let operable = extract(query_params).unwrap();
-    let operation = operable.generate("/pets/:pet_id".to_string());
+    let operation = operable.generate("/pets/{pet_id}".to_string());
 
 
     let operable = extract(json_payload).unwrap();
-    let operation = operable.generate("/pets/:pet_id".to_string());
+    let operation = operable.generate("/pets/{pet_id}".to_string());
 
     let operable = extract_with_state(state_extract).unwrap();
-    let operation = operable.generate("/pets/:pet_id".to_string());
+    let operation = operable.generate("/pets/{pet_id}".to_string());
 }

--- a/gotcha/tests/test_path_params.rs
+++ b/gotcha/tests/test_path_params.rs
@@ -6,7 +6,7 @@ fn test_path_uuid_parameter() {
     use uuid::Uuid;
 
     // Test that Path<Uuid> generates a parameter
-    let url = "/users/:user_id".to_string();
+    let url = "/users/{user_id}".to_string();
     let result = <Path<Uuid> as ParameterProvider>::generate(url);
 
     match result {
@@ -33,7 +33,7 @@ fn test_path_tuple_parameter() {
     use uuid::Uuid;
 
     // Test that Path<(Uuid,)> also works (this should already work)
-    let url = "/users/:user_id".to_string();
+    let url = "/users/{user_id}".to_string();
     let result = <Path<(Uuid,)> as ParameterProvider>::generate(url);
 
     match result {
@@ -56,7 +56,7 @@ fn test_multiple_path_params() {
     use uuid::Uuid;
 
     // Test multiple parameters with Path<(Uuid, String)>
-    let url = "/users/:user_id/posts/:post_id".to_string();
+    let url = "/users/{user_id}/posts/{post_id}".to_string();
     let result = <Path<(Uuid, String)> as ParameterProvider>::generate(url);
 
     match result {

--- a/gotcha_core/Cargo.toml
+++ b/gotcha_core/Cargo.toml
@@ -25,10 +25,10 @@ axum = ["dep:axum", "dep:axum-extra", "dep:regex", "dep:either"]
 [dependencies]
 gotcha_macro = { version = "0.3", path = "../gotcha_macro" }
 oas = "0.1"
-axum = { version = "0.7", default-features = false, features = ["json", "query", "multipart"], optional = true }
+axum = { version = "0.8", default-features = false, features = ["json", "query", "multipart"], optional = true }
 # `TypedHeader<T>` lives here since axum 0.7; the impl must be in this crate because that is where
 # `ParameterProvider` is defined (orphan rule).
-axum-extra = { version = "0.9", default-features = false, features = ["typed-header"], optional = true }
+axum-extra = { version = "0.10", default-features = false, features = ["typed-header"], optional = true }
 regex = { version = "1", optional = true }
 either = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"] }

--- a/gotcha_core/src/parameter.rs
+++ b/gotcha_core/src/parameter.rs
@@ -42,7 +42,8 @@ fn build_param(name: String, _in: ParameterIn, required: bool, schema: Schema, d
 
 impl<T1: Schematic> ParameterProvider for Path<(T1,)> {
     fn generate(url: String) -> Either<Vec<Parameter>, RequestBody> {
-        let pattern = regex::Regex::new(r":([^/]+)").unwrap();
+        // Since axum 0.8 a captured segment is written `{name}`, matching OpenAPI's own syntax.
+        let pattern = regex::Regex::new(r"\{([^}]+)\}").unwrap();
         let param_names_in_path: Vec<String> = pattern.captures_iter(&url).map(|digits| digits.get(1).unwrap().as_str().to_string()).collect();
 
         let t1_param = build_param(
@@ -58,7 +59,8 @@ impl<T1: Schematic> ParameterProvider for Path<(T1,)> {
 
 impl<T1: Schematic, T2: Schematic> ParameterProvider for Path<(T1, T2)> {
     fn generate(url: String) -> Either<Vec<Parameter>, RequestBody> {
-        let pattern = regex::Regex::new(r":([^/]+)").unwrap();
+        // Since axum 0.8 a captured segment is written `{name}`, matching OpenAPI's own syntax.
+        let pattern = regex::Regex::new(r"\{([^}]+)\}").unwrap();
         let param_names_in_path: Vec<String> = pattern.captures_iter(&url).map(|digits| digits.get(1).unwrap().as_str().to_string()).collect();
 
         let t1_param = build_param(
@@ -97,7 +99,8 @@ impl<T: Schematic> ParameterProvider for Path<T> {
             }
         } else {
             // Case 2: Simple type like Uuid - extract parameter name from URL
-            let pattern = regex::Regex::new(r":([^/]+)").unwrap();
+            // Since axum 0.8 a captured segment is written `{name}`, matching OpenAPI's own syntax.
+            let pattern = regex::Regex::new(r"\{([^}]+)\}").unwrap();
             let param_names_in_path: Vec<String> = pattern.captures_iter(&url).map(|digits| digits.get(1).unwrap().as_str().to_string()).collect();
 
             if let Some(param_name) = param_names_in_path.first() {


### PR DESCRIPTION
Three things at once, because they belong in the same breaking release.

## 1. axum 0.7 → 0.8

The headline change is **path syntax**: a captured segment is written `{id}`, not `:id`, and axum refuses the old form at startup rather than matching it literally:

```
Path segments must not start with `:`. For capture groups, use `{capture}`.
```

That is a breaking change for every application's routes, which is exactly why it belongs here rather than in 0.5 — asking users to migrate their config in 0.4 and their routes in 0.5 is two disruptions where one will do.

It also **simplifies gotcha**: `{id}` is what OpenAPI already used, so the framework no longer translates between the two syntaxes. `replace_path_variable` becomes the identity (kept, documented, and tested as such), and the parameter-name extraction in `ParameterProvider` reads `{name}`.

Other adjustments the upgrade forced:

- **axum-core 0.5 dropped `#[async_trait]`** from its extractor traits, so `Valid`, `Header` and `Cookie` use a plain `async fn` — reversing the attribute that E0195 demanded under 0.7.
- **`Router::layer` gained `Sync` bounds**, mirrored on `GotchaRouter::layer` and the builder.
- axum-extra 0.10, axum-macros 0.5, axum-prometheus 0.8; the two examples carrying their own `axum` dependency move too.
- `http = "0.2"` dropped — unused, and two major versions behind what axum itself uses.

## 2. `fallback_service`

Unmatched requests can now go to a `Service` rather than a handler — serving an SPA's `index.html` with `ServeFile`, or forwarding to a proxy, where `fallback` would need a wrapper.

## 3. The extractors that were there but unreachable

Re-exported, so none of these need `gotcha::axum::…` any more:

| | note |
|---|---|
| `Form`, `Multipart` | the features were **already enabled** and `Multipart` already had a `ParameterProvider` impl — they were simply never re-exported |
| `Sse`, `Event`, `KeepAlive` | needed no new axum feature |
| `WebSocketUpgrade`, `WebSocket` | turns on axum's `ws` feature |
| `middleware` | for `middleware::from_fn` |
| `MatchedPath`, `OriginalUri` | turns on `matched-path` / `original-uri` |

The websocket frame type stays behind `ws::Message`, because `Message` is already the message-system trait — re-exporting it bare would have been an ambiguity.

## Tests

`tests/pass/handler/axum_surface.rs` exercises all of it: a urlencoded body, a multipart upload, an SSE stream, a websocket upgrade that echoes a frame, `MatchedPath`/`OriginalUri`, `middleware::from_fn`, and `fallback_service`.

## Migration

`MIGRATION.md` now leads the 0.4 section with the route-path change, since it is the edit every application must make — ahead of the configuration change it previously led with.

## Verification

Workspace builds with `--all-features`, every feature combination tests, `clippy --all-features --workspace`, `fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)